### PR TITLE
Fix compatibility with new BitStream 

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,7 +10,10 @@ This is a log of changes made to the library over time
 # Version Release Notes
 Release notes for the `space_packet_parser` library
 
-## 4.0.2 (released)
+## v4.1.0 (unreleased)
+- Bugfix in fill_buffer to allow compatibility with Bitstring 4.1.1
+
+## v4.0.2 (released)
 - Documentation updates for Read The Docs
 
 ## v4.0.1 (released)


### PR DESCRIPTION
Shows up when filling our BitStream ring buffer for reading large binary files in chunks. Previously, += added new data to the buffer but left the cursor (pos) in place. New behavior moves the cursor to the end of the BitStream. This fix forces that cursor to stay put when filling the ring buffer.