### PR TITLE
Remove upper pin restriction on the package

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,8 +8,8 @@ jobs:
   python-version-matrix:
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
-        bitstring-version: ["", "3.0.0"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        bitstring-version: ["", "3.0.0", "4.1.2"]
     uses: ./.github/workflows/test-python-version.yml
     with:
       python-version: ${{ matrix.python-version }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ maintainers = [
     "Gavin Medley <gavin.medley@lasp.colorado.edu>"
 ]
 repository = "https://github.com/medley56/space_packet_parser"
-homepage = ""
+homepage = "https://space-packet-parser.readthedocs.io"
 keywords = [
     "ccsds",
     "xtce",
@@ -34,8 +34,8 @@ keywords = [
 ]
 
 [tool.poetry.dependencies]
-python = ">=3.8,<3.12"
-bitstring = ">=3.0.0,<4.2"
+python = ">=3.8"
+bitstring = ">=3.0.0"
 
 [tool.poetry.group.dev.dependencies]
 pylint = "^2"


### PR DESCRIPTION
This allows installation with Python 3.12+ and newer versions of bitstring as well.

homepage also must be a uri and not an empty string, so I added that in.