### PR TITLE
Use `lxml` instead of standard library `xml` to improve namespace identification

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ keywords = [
 
 [tool.poetry.dependencies]
 python = ">=3.8"
+lxml = ">=4.8.0"
 
 [tool.poetry.group.dev.dependencies]
 pycodestyle = "*"

--- a/space_packet_parser/xtcedef.py
+++ b/space_packet_parser/xtcedef.py
@@ -7,7 +7,8 @@ import logging
 import struct
 from typing import Tuple, Union, Optional, Any, List, TextIO, Dict
 import warnings
-from xml.etree import ElementTree
+# Installed
+import lxml.etree as ElementTree
 
 logger = logging.getLogger(__name__)
 
@@ -2322,7 +2323,6 @@ FlattenedContainer = namedtuple('FlattenedContainer', ['entry_list', 'restrictio
 class XtcePacketDefinition:
     """Object representation of the XTCE definition of a CCSDS packet object"""
 
-    _default_namespace = {'xtce': 'http://www.omg.org/space/xtce'}
     _tag_to_type_template = {
         '{{{xtce}}}StringParameterType': StringParameterType,
         '{{{xtce}}}IntegerParameterType': IntegerParameterType,
@@ -2352,10 +2352,10 @@ class XtcePacketDefinition:
         self._sequence_container_cache = {}  # Lookup for parsed sequence container objects
         self._parameter_cache = {}  # Lookup for parsed parameter objects
         self._parameter_type_cache = {}  # Lookup for parsed parameter type objects
-        self.ns = ns or self._default_namespace
+        self.tree = ElementTree.parse(xtce_document)
+        self.ns = ns or self.tree.getroot().nsmap
         self.type_tag_to_object = {k.format(**self.ns): v for k, v in
                                    self._tag_to_type_template.items()}
-        self.tree = ElementTree.parse(xtce_document)
 
         self._populate_sequence_container_cache()
 

--- a/tests/unit/test_xtcedef.py
+++ b/tests/unit/test_xtcedef.py
@@ -1,8 +1,8 @@
 """Tests for space_packet_parser.xtcedef"""
 # Standard
-from io import StringIO
-import pytest
+import io
 # Installed
+import pytest
 import lxml.etree as ElementTree
 # Local
 from space_packet_parser import xtcedef, parser
@@ -39,9 +39,9 @@ def test_invalid_parameter_type_error(test_data_dir):
     </xtce:TelemetryMetaData>
 </xtce:SpaceSystem>
 """
-    x = StringIO(test_xtce_document)
+    x = io.TextIOWrapper(io.BytesIO(test_xtce_document.encode("utf-8")))
     with pytest.raises(xtcedef.InvalidParameterTypeError):
-        xtcedef.XtcePacketDefinition(x, ns=TEST_NAMESPACE)
+        xtcedef.XtcePacketDefinition(x)
 
 
 def test_unsupported_parameter_type_error(test_data_dir):
@@ -80,9 +80,9 @@ def test_unsupported_parameter_type_error(test_data_dir):
     </xtce:TelemetryMetaData>
 </xtce:SpaceSystem>
 """
-    x = StringIO(test_xtce_document)
+    x = io.TextIOWrapper(io.BytesIO(test_xtce_document.encode("utf-8")))
     with pytest.raises(NotImplementedError):
-        xtcedef.XtcePacketDefinition(x, ns=TEST_NAMESPACE)
+        xtcedef.XtcePacketDefinition(x)
 
 
 def test_attr_comparable():

--- a/tests/unit/test_xtcedef.py
+++ b/tests/unit/test_xtcedef.py
@@ -2,7 +2,8 @@
 # Standard
 from io import StringIO
 import pytest
-from xml.etree import ElementTree
+# Installed
+import lxml.etree as ElementTree
 # Local
 from space_packet_parser import xtcedef, parser
 


### PR DESCRIPTION
Changes in this PR:
- Instead of hardcoding a `XtcePacketDefinition._default_namespace`, read the namespace from the XTCE document.
  - This requires the `lxml` module instead of the built-in `xml`, since the latter's `Element` does not have an `nsmap` attribute.
- Adds new `lxml` dependency to the list of requirements.
  - Since `XtcePacketDefinition.__init__`'s `xtce_document` argument might be a `Path`, we need a version &ge;4.8, since [that's when support was added for `Path` objects](https://lxml.de/4.8/changes-4.8.0.html).
- Switches to `lxml` in tests as well, for consistency.