### PR TITLE
Add `BooleanParameterType` class

### DIFF
--- a/space_packet_parser/xtcedef.py
+++ b/space_packet_parser/xtcedef.py
@@ -1742,6 +1742,11 @@ class IntegerParameterType(ParameterType):
     pass
 
 
+class BooleanParameterType(ParameterType):
+    """<xtce:BooleanParameterType>"""
+    pass
+
+
 class FloatParameterType(ParameterType):
     """<xtce:FloatParameterType>"""
     pass
@@ -1948,6 +1953,7 @@ class XtcePacketDefinition:
     _tag_to_type_template = {
         '{{{xtce}}}StringParameterType': StringParameterType,
         '{{{xtce}}}IntegerParameterType': IntegerParameterType,
+        '{{{xtce}}}BooleanParameterType': BooleanParameterType,
         '{{{xtce}}}FloatParameterType': FloatParameterType,
         '{{{xtce}}}EnumeratedParameterType': EnumeratedParameterType,
         '{{{xtce}}}BinaryParameterType': BinaryParameterType,

--- a/space_packet_parser/xtcedef.py
+++ b/space_packet_parser/xtcedef.py
@@ -1747,6 +1747,16 @@ class BooleanParameterType(ParameterType):
     pass
 
 
+class AbsoluteTimeParameterType(ParameterType):
+    """<xtce:AbsoluteTimeParameterType>"""
+    pass
+
+
+class RelativeTimeParameterType(ParameterType):
+    """<xtce:RelativeTimeParameterType>"""
+    pass
+
+
 class FloatParameterType(ParameterType):
     """<xtce:FloatParameterType>"""
     pass
@@ -1955,6 +1965,8 @@ class XtcePacketDefinition:
         '{{{xtce}}}IntegerParameterType': IntegerParameterType,
         '{{{xtce}}}BooleanParameterType': BooleanParameterType,
         '{{{xtce}}}FloatParameterType': FloatParameterType,
+        '{{{xtce}}}AbsoluteTimeParameterType': AbsoluteTimeParameterType,
+        '{{{xtce}}}RelativeTimeParameterType': RelativeTimeParameterType,
         '{{{xtce}}}EnumeratedParameterType': EnumeratedParameterType,
         '{{{xtce}}}BinaryParameterType': BinaryParameterType,
     }


### PR DESCRIPTION
Very straightforward update to add support for `BooleanParameterType` fields. This doesn't have/need its own encoding type/class&mdash;it would most likely be defined using an `IntegerDataEncoding`.