### PR TITLE
Add more `*ParameterType` classes

### DIFF
--- a/space_packet_parser/xtcedef.py
+++ b/space_packet_parser/xtcedef.py
@@ -1742,6 +1742,11 @@ class IntegerParameterType(ParameterType):
     pass
 
 
+class BooleanParameterType(ParameterType):
+    """<xtce:BooleanParameterType>"""
+    pass
+
+
 class FloatParameterType(ParameterType):
     """<xtce:FloatParameterType>"""
     pass
@@ -1948,6 +1953,7 @@ class XtcePacketDefinition:
     _tag_to_type_template = {
         '{{{xtce}}}StringParameterType': StringParameterType,
         '{{{xtce}}}IntegerParameterType': IntegerParameterType,
+        '{{{xtce}}}BooleanParameterType': BooleanParameterType,
         '{{{xtce}}}FloatParameterType': FloatParameterType,
         '{{{xtce}}}EnumeratedParameterType': EnumeratedParameterType,
         '{{{xtce}}}BinaryParameterType': BinaryParameterType,

--- a/space_packet_parser/xtcedef.py
+++ b/space_packet_parser/xtcedef.py
@@ -1693,7 +1693,7 @@ class ParameterType(AttrComparable, metaclass=ABCMeta):
         """
         for data_encoding in [StringDataEncoding, IntegerDataEncoding, FloatDataEncoding, BinaryDataEncoding]:
             # Try to find each type of data encoding element. If we find one, we assume it's the only one.
-            element = parameter_type_element.find(f"xtce:{data_encoding.__name__}", ns)
+            element = parameter_type_element.find(f".//xtce:{data_encoding.__name__}", ns)
             if element is not None:
                 return data_encoding.from_data_encoding_xml_element(element, ns)
 

--- a/space_packet_parser/xtcedef.py
+++ b/space_packet_parser/xtcedef.py
@@ -1747,6 +1747,16 @@ class BooleanParameterType(ParameterType):
     pass
 
 
+class AbsoluteTimeParameterType(ParameterType):
+    """<xtce:AbsoluteTimeParameterType>"""
+    pass
+
+
+class RelativeTimeParameterType(ParameterType):
+    """<xtce:RelativeTimeParameterType>"""
+    pass
+
+
 class FloatParameterType(ParameterType):
     """<xtce:FloatParameterType>"""
     pass
@@ -1955,6 +1965,8 @@ class XtcePacketDefinition:
         '{{{xtce}}}IntegerParameterType': IntegerParameterType,
         '{{{xtce}}}BooleanParameterType': BooleanParameterType,
         '{{{xtce}}}FloatParameterType': FloatParameterType,
+        '{{{xtce}}}AbsoluteTimeParameterType': AbsoluteTimeParameterType,
+        '{{{xtce}}}RelativeTimeParameterType': RelativeTimeParameterType,
         '{{{xtce}}}EnumeratedParameterType': EnumeratedParameterType,
         '{{{xtce}}}BinaryParameterType': BinaryParameterType,
     }


### PR DESCRIPTION
Straightforward PR that adds the following classes:
- `BooleanParameterType`
- `AbsoluteTimeParameterType`
- `RelativeTimeParameterType`

This is a rehash of #19 that includes the latter two time classes as well. As I noted there, none of these should need any additional encoding definitions, as they would all typically use an `IntegerDataEncoding` or `FloatDataEncoding`.