### PR TITLE
Parsing Parameter Short and Long Descriptions

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -9,4 +9,3 @@ Brief description of changes. If you write good commit messages, put the concate
 - [ ] Current dependencies have been properly specified and old dependencies removed
 - [ ] New code/functionality has accompanying tests and any old tests have been updated to match any new assumptions
 - [ ] The changelog.md has been updated
-- [ ] Code has been reviewed by a code owner and/or trusted contributor

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,7 +1,7 @@
 cff-version: 1.2.0
 title: 'space_packet_parser'
 type: software
-version: '4.1.0'
+version: '4.1.1'
 description: A CCSDS telemetry packet decoding library based on the XTCE packet format description standard.
 license: BSD-3-Clause
 abstract: The space_packet_parser Python library is a generalized, configurable packet decoding library for CCSDS telemetry
@@ -21,9 +21,12 @@ authors:
 - email: michael.chambliss@lasp.colorado.edu
   name: Michael Chambliss
   orcid: "0009-0003-7493-0542"
+- email: greg.lucas@lasp.colorado.edu
+  name: Greg Lucas
+  orcid: "0000-0003-1331-1863"
 maintainers:
 - email: gavin.medley@lasp.colorado.edu
   name: Gavin Medley
   orcid: "0000-0002-3520-9715"
 repository-code: "https://github.com/medley56/space_packet_parser"
-url: "TBD"
+url: "https://space-packet-parser.readthedocs.io"

--- a/docs/source/changelog.md
+++ b/docs/source/changelog.md
@@ -13,6 +13,7 @@ Release notes for the `space_packet_parser` library
 ### v4.2.0 (unreleased)
 - Parse short and long descriptions of parameters
 - Implement equality checking for SequenceContainer objects and Parameter objects
+- Include parameter short description and long description in ParsedDataItems
 
 ### v4.1.1 (released)
 - Allow Python 3.12

--- a/docs/source/changelog.md
+++ b/docs/source/changelog.md
@@ -10,6 +10,10 @@ This is a log of changes made to the library over time
 ## Version Release Notes
 Release notes for the `space_packet_parser` library
 
+### v4.2.0 (unreleased)
+- Parse short and long descriptions of parameters
+- Implement equality checking for SequenceContainer objects and Parameter objects
+
 ### v4.1.1 (released)
 - Allow Python 3.12
 

--- a/docs/source/users.md
+++ b/docs/source/users.md
@@ -16,7 +16,14 @@ from space_packet_parser import xtcedef, parser
 packet_file = Path('my_packets.pkts')
 xtce_document = Path('my_xtce_document.xml')
 packet_definition = xtcedef.XtcePacketDefinition(xtce_document)
-my_parser = parser.PacketParser(packet_definition)
+
+# You can introspect the packet definition to learn about what was parsed
+pt = packet_definition.named_parameter_types["MY_PARAM_Type"]  # Look up a type (includes unit and encoding info)
+p = packet_definition.named_parameters['MY_PARAM']  # Look up a parameter (includes short and long descriptions)
+sc = packet_definition.named_containers['SecondaryHeaderContainer']  # Look up a sequence container (includes inheritance)
+# See the API docs for more information about the ParameterType, Parameter, and SequenceContainer classes
+
+my_parser = parser.PacketParser(packet_definition)  # Set up a packet parser from your definition
 
 with packet_file.open("rb") as binary_data:
     packet_generator = my_parser.generator(binary_data)

--- a/examples/parsing_and_plotting_idex_waveforms_from_socket.py
+++ b/examples/parsing_and_plotting_idex_waveforms_from_socket.py
@@ -100,7 +100,6 @@ if __name__ == "__main__":
 
     sender, receiver = socket.socketpair()
     receiver.settimeout(3)
-    file = '/Users/game1390/Workspace/space/space_packet_parser/tests/test_data/jpss/J01_G011_LZ_2021-04-09T00-00-00Z_V01.DAT1'
     p = Process(target=send_data, args=(sender, idex_packet_file,))
     p.start()
 

--- a/space_packet_parser/parser.py
+++ b/space_packet_parser/parser.py
@@ -35,7 +35,8 @@ Packet = namedtuple('Packet', ['header', 'data'])
 class ParsedDataItem(xtcedef.AttrComparable):
     """Representation of a parsed parameter"""
 
-    def __init__(self, name: str, raw_value: any, unit: str = None, derived_value: float or str = None):
+    def __init__(self, name: str, raw_value: any, unit: str = None, derived_value: float or str = None,
+                 short_description: str = None, long_description: str = None):
         """Constructor
 
         Parameters
@@ -48,6 +49,10 @@ class ParsedDataItem(xtcedef.AttrComparable):
             Raw representation of the parsed value. May be lots of different types but most often an integer
         derived_value : float or str
             May be a calibrated value or an enum lookup
+        short_description : str
+            Parameter short description
+        long_description : str
+            Parameter long description
         """
         if name is None or raw_value is None:
             raise ValueError("Invalid ParsedDataItem. Must define name and raw_value.")
@@ -55,6 +60,8 @@ class ParsedDataItem(xtcedef.AttrComparable):
         self.raw_value = raw_value
         self.unit = unit
         self.derived_value = derived_value
+        self.short_description = short_description
+        self.long_description = long_description
 
     def __repr__(self):
         return (f"{self.__class__.__name__}("
@@ -237,7 +244,9 @@ class PacketParser:
                 name=p.name,
                 unit=p.parameter_type.unit,
                 raw_value=parsed_value,
-                derived_value=derived_value
+                derived_value=derived_value,
+                short_description=p.short_description,
+                long_description=p.long_description
             )
 
         def _parse_sequence_container(sc: xtcedef.SequenceContainer):
@@ -320,7 +329,9 @@ class PacketParser:
                 name=parameter.name,
                 unit=parameter.parameter_type.unit,
                 raw_value=parsed_value,
-                derived_value=derived_value
+                derived_value=derived_value,
+                short_description=parameter.short_description,
+                long_description=parameter.long_description
             )
 
         return Packet(header=header, data=user_data)

--- a/tests/integration/test_xtce_based_parsing/test_jpss_parsing.py
+++ b/tests/integration/test_xtce_based_parsing/test_jpss_parsing.py
@@ -21,5 +21,7 @@ def test_jpss_xtce_packet_parsing(jpss_test_data_dir):
             assert isinstance(jpss_packet, parser.Packet)
             assert jpss_packet.header['PKT_APID'].raw_value == 11
             assert jpss_packet.header['VERSION'].raw_value == 0
+            assert jpss_packet.data['USEC'].short_description == "Secondary Header Fine Time (microsecond)"
+            assert jpss_packet.data['USEC'].long_description == "CCSDS Packet 2nd Header Fine Time in microseconds."
             n_packets += 1
         assert n_packets == 7200

--- a/tests/test_data/test_xtce.xml
+++ b/tests/test_data/test_xtce.xml
@@ -1,0 +1,205 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<xtce:SpaceSystem xmlns:xtce="http://www.omg.org/space/xtce" name="Space Packet Parser">
+    <xtce:Header date="2024-03-05T13:36:00MST" version="1.0" author="Gavin Medley"/>
+    <xtce:TelemetryMetaData>
+        <xtce:ParameterTypeSet>
+            <xtce:IntegerParameterType name="VERSION_Type" signed="false">
+                <xtce:UnitSet/>
+                <xtce:IntegerDataEncoding sizeInBits="3" encoding="unsigned"/>
+            </xtce:IntegerParameterType>
+            <xtce:IntegerParameterType name="TYPE_Type" signed="false">
+                <xtce:UnitSet/>
+                <xtce:IntegerDataEncoding sizeInBits="1" encoding="unsigned"/>
+            </xtce:IntegerParameterType>
+            <xtce:IntegerParameterType name="SEC_HDR_FLG_Type" signed="false">
+                <xtce:UnitSet/>
+                <xtce:IntegerDataEncoding sizeInBits="1" encoding="unsigned"/>
+            </xtce:IntegerParameterType>
+            <xtce:IntegerParameterType name="PKT_APID_Type" signed="false">
+                <xtce:UnitSet/>
+                <xtce:IntegerDataEncoding sizeInBits="11" encoding="unsigned"/>
+            </xtce:IntegerParameterType>
+            <xtce:IntegerParameterType name="SEQ_FLGS_Type" signed="false">
+                <xtce:UnitSet/>
+                <xtce:IntegerDataEncoding sizeInBits="2" encoding="unsigned"/>
+            </xtce:IntegerParameterType>
+            <xtce:IntegerParameterType name="SRC_SEQ_CTR_Type" signed="false">
+                <xtce:UnitSet/>
+                <xtce:IntegerDataEncoding sizeInBits="14" encoding="unsigned"/>
+            </xtce:IntegerParameterType>
+            <xtce:IntegerParameterType name="PKT_LEN_Type" signed="false">
+                <xtce:UnitSet/>
+                <xtce:IntegerDataEncoding sizeInBits="16" encoding="unsigned"/>
+            </xtce:IntegerParameterType>
+            <xtce:FloatParameterType name="DOY_Type">
+                <xtce:UnitSet>
+                    <xtce:Unit>day</xtce:Unit>
+                </xtce:UnitSet>
+                <xtce:IntegerDataEncoding sizeInBits="16" encoding="unsigned"/>
+            </xtce:FloatParameterType>
+            <xtce:FloatParameterType name="MSEC_Type">
+                <xtce:UnitSet>
+                    <xtce:Unit>ms</xtce:Unit>
+                </xtce:UnitSet>
+                <xtce:IntegerDataEncoding sizeInBits="32" encoding="unsigned"/>
+            </xtce:FloatParameterType>
+            <xtce:FloatParameterType name="USEC_Type">
+                <xtce:UnitSet>
+                    <xtce:Unit>us</xtce:Unit>
+                </xtce:UnitSet>
+                <xtce:IntegerDataEncoding sizeInBits="16" encoding="unsigned"/>
+            </xtce:FloatParameterType>
+            <xtce:IntegerParameterType name="ADASCID_Type" signed="false">
+                <xtce:UnitSet/>
+                <xtce:IntegerDataEncoding sizeInBits="8" encoding="unsigned"/>
+            </xtce:IntegerParameterType>
+            <xtce:IntegerParameterType name="ADAETDAY_Type" signed="false">
+                <xtce:UnitSet>
+                    <xtce:Unit>day</xtce:Unit>
+                </xtce:UnitSet>
+                <xtce:IntegerDataEncoding sizeInBits="16" encoding="unsigned"/>
+            </xtce:IntegerParameterType>
+            <xtce:IntegerParameterType name="ADAETMS_Type" signed="false">
+                <xtce:UnitSet>
+                    <xtce:Unit>ms</xtce:Unit>
+                </xtce:UnitSet>
+                <xtce:IntegerDataEncoding sizeInBits="32" encoding="unsigned"/>
+            </xtce:IntegerParameterType>
+            <xtce:IntegerParameterType name="ADAETUS_Type" signed="false">
+                <xtce:UnitSet>
+                    <xtce:Unit>us</xtce:Unit>
+                </xtce:UnitSet>
+                <xtce:IntegerDataEncoding sizeInBits="16" encoding="unsigned"/>
+            </xtce:IntegerParameterType>
+            <xtce:FloatParameterType name="ADGPSPOS_Type">
+                <xtce:UnitSet>
+                    <xtce:Unit>m</xtce:Unit>
+                </xtce:UnitSet>
+                <xtce:FloatDataEncoding sizeInBits="32" encoding="IEEE-754"/>
+            </xtce:FloatParameterType>
+            <xtce:FloatParameterType name="ADGPSVEL_Type">
+                <xtce:UnitSet>
+                    <xtce:Unit>m/s</xtce:Unit>
+                </xtce:UnitSet>
+                <xtce:FloatDataEncoding sizeInBits="32" encoding="IEEE-754"/>
+            </xtce:FloatParameterType>
+            <xtce:FloatParameterType name="ADCFAQ_Type">
+                <xtce:UnitSet/>
+                <xtce:FloatDataEncoding sizeInBits="32" encoding="IEEE-754"/>
+            </xtce:FloatParameterType>
+        </xtce:ParameterTypeSet>
+        <xtce:ParameterSet>
+            <xtce:Parameter name="VERSION" parameterTypeRef="VERSION_Type">
+                <xtce:LongDescription>Not really used. We aren't changing the version of CCSDS that we use.</xtce:LongDescription>
+            </xtce:Parameter>
+            <xtce:Parameter name="TYPE" parameterTypeRef="TYPE_Type">
+                <xtce:LongDescription>Indicates whether this packet is CMD or TLM. TLM is 0.</xtce:LongDescription>
+            </xtce:Parameter>
+            <xtce:Parameter name="SEC_HDR_FLG" parameterTypeRef="SEC_HDR_FLG_Type">
+                <xtce:LongDescription>Always 1 - indicates that there is a secondary header.</xtce:LongDescription>
+            </xtce:Parameter>
+            <xtce:Parameter name="PKT_APID" parameterTypeRef="PKT_APID_Type">
+                <xtce:LongDescription>Unique to each packet type.</xtce:LongDescription>
+            </xtce:Parameter>
+            <xtce:Parameter name="SEQ_FLGS" parameterTypeRef="SEQ_FLGS_Type">
+                <xtce:LongDescription>Always set to 1.</xtce:LongDescription>
+            </xtce:Parameter>
+            <xtce:Parameter name="SRC_SEQ_CTR" parameterTypeRef="SRC_SEQ_CTR_Type">
+                <xtce:LongDescription>Increments from 0 at reset for each packet issued of that APID. Rolls over at 14b.</xtce:LongDescription>
+            </xtce:Parameter>
+            <xtce:Parameter name="PKT_LEN" parameterTypeRef="PKT_LEN_Type">
+                <xtce:LongDescription>Number of bytes of the data field following the primary header -1. (To get the length of the whole packet, add 7)</xtce:LongDescription>
+            </xtce:Parameter>
+            <xtce:Parameter name="DOY" parameterTypeRef="DOY_Type" shortDescription="Secondary Header Day of Year">
+                <xtce:LongDescription>CCSDS Packet 2nd Header Day of Year in days.</xtce:LongDescription>
+            </xtce:Parameter>
+            <xtce:Parameter name="MSEC" parameterTypeRef="MSEC_Type" shortDescription="Secondary Header Coarse Time (millisecond)">
+                <xtce:LongDescription>CCSDS Packet 2nd Header Coarse Time in milliseconds.</xtce:LongDescription>
+            </xtce:Parameter>
+            <xtce:Parameter name="USEC" parameterTypeRef="USEC_Type" shortDescription="Secondary Header Fine Time (microsecond)">
+                <xtce:LongDescription>CCSDS Packet 2nd Header Fine Time in microseconds.</xtce:LongDescription>
+            </xtce:Parameter>
+            <xtce:Parameter name="ADAESCID" parameterTypeRef="ADASCID_Type" shortDescription="Spacecraft ID"/>
+            <xtce:Parameter name="ADAET1DAY" parameterTypeRef="ADAETDAY_Type" shortDescription="Ephemeris Valid Time, Days Since 1/1/1958"/>
+            <xtce:Parameter name="ADAET1MS" parameterTypeRef="ADAETMS_Type" shortDescription="Ephemeris Valid Time, Milliseconds of Day"/>
+            <xtce:Parameter name="ADAET1US" parameterTypeRef="ADAETUS_Type" shortDescription="Ephemeris Valid Time, Microseconds of Milliseconds"/>
+            <xtce:Parameter name="ADGPSPOSX" parameterTypeRef="ADGPSPOS_Type" shortDescription="Ephemeris Position (ECEF) X"/>
+            <xtce:Parameter name="ADGPSPOSY" parameterTypeRef="ADGPSPOS_Type" shortDescription="Ephemeris Position (ECEF) Y"/>
+            <xtce:Parameter name="ADGPSPOSZ" parameterTypeRef="ADGPSPOS_Type" shortDescription="Ephemeris Position (ECEF) Z"/>
+            <xtce:Parameter name="ADGPSVELX" parameterTypeRef="ADGPSVEL_Type" shortDescription="Ephemeris Velocity (ECEF) X"/>
+            <xtce:Parameter name="ADGPSVELY" parameterTypeRef="ADGPSVEL_Type" shortDescription="Ephemeris Velocity (ECEF) Y"/>
+            <xtce:Parameter name="ADGPSVELZ" parameterTypeRef="ADGPSVEL_Type" shortDescription="Ephemeris Velocity (ECEF) Z"/>
+            <xtce:Parameter name="ADAET2DAY" parameterTypeRef="ADAETDAY_Type" shortDescription="Attitude Valid Time, Days Since 1/1/1958"/>
+            <xtce:Parameter name="ADAET2MS" parameterTypeRef="ADAETMS_Type" shortDescription="Attitude Valid Time, Milliseconds of Day"/>
+            <xtce:Parameter name="ADAET2US" parameterTypeRef="ADAETUS_Type" shortDescription="Attitude Valid Time, Microseconds of Milliseconds"/>
+            <xtce:Parameter name="ADCFAQ1" parameterTypeRef="ADCFAQ_Type" shortDescription="Control Frame Attitude Q1 (i)"/>
+            <xtce:Parameter name="ADCFAQ2" parameterTypeRef="ADCFAQ_Type" shortDescription="Control Frame Attitude Q2 (j)"/>
+            <xtce:Parameter name="ADCFAQ3" parameterTypeRef="ADCFAQ_Type" shortDescription="Control Frame Attitude Q3 (k)"/>
+            <xtce:Parameter name="ADCFAQ4" parameterTypeRef="ADCFAQ_Type" shortDescription="Control Frame Attitude Q4 (scalar)"/>
+        </xtce:ParameterSet>
+        <xtce:ContainerSet>
+            <xtce:SequenceContainer name="CCSDSPacket" abstract="true">
+                <xtce:LongDescription>Super-container for telemetry and command packets</xtce:LongDescription>
+                <xtce:EntryList>
+                    <xtce:ParameterRefEntry parameterRef="VERSION"/>
+                    <xtce:ParameterRefEntry parameterRef="TYPE"/>
+                    <xtce:ParameterRefEntry parameterRef="SEC_HDR_FLG"/>
+                    <xtce:ParameterRefEntry parameterRef="PKT_APID"/>
+                    <xtce:ParameterRefEntry parameterRef="SEQ_FLGS"/>
+                    <xtce:ParameterRefEntry parameterRef="SRC_SEQ_CTR"/>
+                    <xtce:ParameterRefEntry parameterRef="PKT_LEN"/>
+                </xtce:EntryList>
+            </xtce:SequenceContainer>
+            <xtce:SequenceContainer name="CCSDSTelemetryPacket" abstract="true">
+                <xtce:LongDescription>Super-container for all telemetry packets</xtce:LongDescription>
+                <xtce:EntryList/>
+                <xtce:BaseContainer containerRef="CCSDSPacket">
+                    <xtce:RestrictionCriteria>
+                        <xtce:ComparisonList>
+                            <xtce:Comparison parameterRef="VERSION" value="0" useCalibratedValue="false"/>
+                            <xtce:Comparison parameterRef="TYPE" value="0" useCalibratedValue="false"/>
+                        </xtce:ComparisonList>
+                    </xtce:RestrictionCriteria>
+                </xtce:BaseContainer>
+            </xtce:SequenceContainer>
+            <xtce:SequenceContainer name="SecondaryHeaderContainer" abstract="true">
+                <xtce:LongDescription>Container for telemetry secondary header items</xtce:LongDescription>
+                <xtce:EntryList>
+                    <xtce:ParameterRefEntry parameterRef="DOY"/>
+                    <xtce:ParameterRefEntry parameterRef="MSEC"/>
+                    <xtce:ParameterRefEntry parameterRef="USEC"/>
+                </xtce:EntryList>
+            </xtce:SequenceContainer>
+            <xtce:SequenceContainer name="JPSS_ATT_EPHEM" shortDescription="Spacecraft Attitude and Ephemeris">
+                <xtce:LongDescription>Spacecraft Attitude and Ephemeris packet used to geolocate mission data</xtce:LongDescription>
+                <xtce:EntryList>
+                    <xtce:ContainerRefEntry containerRef="SecondaryHeaderContainer"/>
+                    <xtce:ParameterRefEntry parameterRef="ADAESCID"/>
+                    <xtce:ParameterRefEntry parameterRef="ADAET1DAY"/>
+                    <xtce:ParameterRefEntry parameterRef="ADAET1MS"/>
+                    <xtce:ParameterRefEntry parameterRef="ADAET1US"/>
+                    <xtce:ParameterRefEntry parameterRef="ADGPSPOSX"/>
+                    <xtce:ParameterRefEntry parameterRef="ADGPSPOSY"/>
+                    <xtce:ParameterRefEntry parameterRef="ADGPSPOSZ"/>
+                    <xtce:ParameterRefEntry parameterRef="ADGPSVELX"/>
+                    <xtce:ParameterRefEntry parameterRef="ADGPSVELY"/>
+                    <xtce:ParameterRefEntry parameterRef="ADGPSVELZ"/>
+                    <xtce:ParameterRefEntry parameterRef="ADAET2DAY"/>
+                    <xtce:ParameterRefEntry parameterRef="ADAET2MS"/>
+                    <xtce:ParameterRefEntry parameterRef="ADAET2US"/>
+                    <xtce:ParameterRefEntry parameterRef="ADCFAQ1"/>
+                    <xtce:ParameterRefEntry parameterRef="ADCFAQ2"/>
+                    <xtce:ParameterRefEntry parameterRef="ADCFAQ3"/>
+                    <xtce:ParameterRefEntry parameterRef="ADCFAQ4"/>
+                </xtce:EntryList>
+                <xtce:BaseContainer containerRef="CCSDSTelemetryPacket">
+                    <xtce:RestrictionCriteria>
+                        <xtce:ComparisonList>
+                            <xtce:Comparison parameterRef="PKT_APID" value="11" useCalibratedValue="false"/>
+                        </xtce:ComparisonList>
+                    </xtce:RestrictionCriteria>
+                </xtce:BaseContainer>
+            </xtce:SequenceContainer>
+        </xtce:ContainerSet>
+    </xtce:TelemetryMetaData>
+</xtce:SpaceSystem>

--- a/tests/unit/test_parser.py
+++ b/tests/unit/test_parser.py
@@ -7,18 +7,18 @@ from space_packet_parser import parser
 
 
 @pytest.mark.parametrize(
-    ('name', 'raw_value', 'unit', 'derived_value', 'valid'),
+    ('name', 'raw_value', 'unit', 'derived_value', 'short_description', 'long_description', 'valid'),
     [
-        ('TEST', 0, 'smoots', 10, True),
-        ('TEST', 10, None, None, True),
-        (None, 10, 'foo', 10, False),
-        ('TEST', None, None, None, False)
+        ('TEST', 0, 'smoots', 10, "short", "long", True),
+        ('TEST', 10, None, None, None, None, True),
+        (None, 10, 'foo', 10, None, None, False),
+        ('TEST', None, None, None, None, None, False)
     ]
 )
-def test_parsed_data_item(name, raw_value, unit, derived_value, valid):
+def test_parsed_data_item(name, raw_value, unit, derived_value, short_description, long_description, valid):
     """Test ParsedDataItem"""
     if valid:
-        pdi = parser.ParsedDataItem(name, raw_value, unit, derived_value)
+        pdi = parser.ParsedDataItem(name, raw_value, unit, derived_value, short_description, long_description)
     else:
         with pytest.raises(ValueError):
-            pdi = parser.ParsedDataItem(name, raw_value, unit, derived_value)
+            pdi = parser.ParsedDataItem(name, raw_value, unit, derived_value, short_description, long_description)

--- a/tests/unit/test_xtcedef.py
+++ b/tests/unit/test_xtcedef.py
@@ -1388,4 +1388,87 @@ def test_parameter():
                       parameter_type=xtcedef.IntegerParameterType(
                        name='TEST_INT_Type',
                        unit='floops',
-                       encoding=xtcedef.IntegerDataEncoding(size_in_bits=16, encoding='unsigned')))
+                       encoding=xtcedef.IntegerDataEncoding(size_in_bits=16, encoding='unsigned')),
+                      short_description="Param short desc",
+                      long_description="This is a long description of the parameter")
+
+
+# -----------------------
+# Full XTCE Document Test
+# -----------------------
+def test_parsing_xtce_document(test_data_dir):
+    """Tests parsing an entire XTCE document and makes assertions about the contents"""
+    with open(test_data_dir / "test_xtce.xml") as x:
+        xdef = xtcedef.XtcePacketDefinition(x, ns=TEST_NAMESPACE)
+
+    # Test Parameter Types
+    ptname = "USEC_Type"
+    pt = xdef.named_parameter_types[ptname]
+    assert pt.name == ptname
+    assert pt.unit == "us"
+    assert isinstance(pt.encoding, xtcedef.IntegerDataEncoding)
+
+    # Test Parameters
+    pname = "ADAET1DAY"  # Named parameter
+    p = xdef.named_parameters[pname]
+    assert p.name == pname
+    assert p.short_description == "Ephemeris Valid Time, Days Since 1/1/1958"
+    assert p.long_description is None
+
+    pname = "USEC"
+    p = xdef.named_parameters[pname]
+    assert p.name == pname
+    assert p.short_description == "Secondary Header Fine Time (microsecond)"
+    assert p.long_description == "CCSDS Packet 2nd Header Fine Time in microseconds."
+
+    # Test Sequence Containers
+    scname = "SecondaryHeaderContainer"
+    sc = xdef.named_containers[scname]
+    assert sc.name == scname
+    assert sc == xtcedef.SequenceContainer(
+        name=scname,
+        entry_list=[
+            xtcedef.Parameter(
+                name="DOY",
+                parameter_type=xtcedef.FloatParameterType(
+                    name="DOY_Type",
+                    encoding=xtcedef.IntegerDataEncoding(
+                        size_in_bits=16, encoding="unsigned"
+                    ),
+                    unit="day"
+                ),
+                short_description="Secondary Header Day of Year",
+                long_description="CCSDS Packet 2nd Header Day of Year in days."
+            ),
+            xtcedef.Parameter(
+                name="MSEC",
+                parameter_type=xtcedef.FloatParameterType(
+                    name="MSEC_Type",
+                    encoding=xtcedef.IntegerDataEncoding(
+                        size_in_bits=32, encoding="unsigned"
+                    ),
+                    unit="ms"
+                ),
+                short_description="Secondary Header Coarse Time (millisecond)",
+                long_description="CCSDS Packet 2nd Header Coarse Time in milliseconds."
+            ),
+            xtcedef.Parameter(
+                name="USEC",
+                parameter_type=xtcedef.FloatParameterType(
+                    name="USEC_Type",
+                    encoding=xtcedef.IntegerDataEncoding(
+                        size_in_bits=16, encoding="unsigned"
+                    ),
+                    unit="us"
+                ),
+                short_description="Secondary Header Fine Time (microsecond)",
+                long_description="CCSDS Packet 2nd Header Fine Time in microseconds."
+            )
+        ],
+        short_description=None,
+        long_description="Container for telemetry secondary header items",
+        base_container_name=None,
+        restriction_criteria=None,
+        abstract=True,
+        inheritors=None
+    )


### PR DESCRIPTION
# Parsing Parameter Short and Long Descriptions

Feature request to parse the short and long descriptions of Parameter objects. I also added a pretty comprehensive parsing test for a full XTCE document and changed Parameter and SequenceContainer to inherit from AttrComparable so we can assert on the resulting parsed objects.


## Checklist
- [x] Changes are fully implemented without dangling issues or TODO items
- [x] Deprecated/superseded code is removed or marked with deprecation warning
- [x] Current dependencies have been properly specified and old dependencies removed
- [x] New code/functionality has accompanying tests and any old tests have been updated to match any new assumptions
- [x] The changelog.md has been updated
- [x] Code has been reviewed by a code owner and/or trusted contributor
