### PR TITLE
PERF: Use bytes objects for the buffer rather than bitstring

### DIFF
--- a/docs/source/changelog.md
+++ b/docs/source/changelog.md
@@ -17,6 +17,7 @@ Release notes for the `space_packet_parser` library
 - Add support for BooleanParameterType
 - Drop support for bitstring <4.0.1
 - Support BooleanExpression in a ContextCalibrator
+- Default read size is changed to a full file read on file-like objects
 
 ### v4.1.1 (released)
 - Allow Python 3.12


### PR DESCRIPTION
# Title of PR

This uses bytes objects directly in the buffers. Keeping track of the current position manually. Currently, this provides a modest speedup for full packet parsing because we still create a new ConstBitStream for each packet parsing. But for `ccsds_header_only=True` we get a 10x speedup.

I'm opening this as a draft for now to aid discussion.

The other thing that helped with the speed here is defaulting to a full read of a file rather than `file.read(4096)` as it was before and creating lots of small appends to the bytes buffer. Happy to remove this if you'd prefer people to input -1 manually to get that, but figured it is likely what people would want (may be wrong there).

closes #33

## Checklist
- [x] Changes are fully implemented without dangling issues or TODO items
- [n/a] Deprecated/superseded code is removed or marked with deprecation warning
- [n/a] Current dependencies have been properly specified and old dependencies removed
- [n/a] New code/functionality has accompanying tests and any old tests have been updated to match any new assumptions
- [x] The changelog.md has been updated
