### PR TITLE
Add run-pylint.yml Action to lint code on all pushes and PRs

### DIFF
--- a/.github/workflows/run-pylint.yml
+++ b/.github/workflows/run-pylint.yml
@@ -1,0 +1,12 @@
+name: Run Pylint
+on: [push, pull_request]
+jobs:
+  pylint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repo
+        uses: actions/checkout@v4
+      - name: Build Docker image
+        run: docker build . --file Dockerfile --target lint --tag space-packet-parser-lint:latest
+      - name: Run Pylint in Docker
+        run: docker run -i space-packet-parser-lint:latest

--- a/.github/workflows/test-python-version.yml
+++ b/.github/workflows/test-python-version.yml
@@ -15,8 +15,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-    - uses: actions/checkout@v3
-    - name: Build Test Docker Image
-      run: docker build . --file Dockerfile --build-arg BASE_IMAGE_PYTHON_VERSION=${{ inputs.python-version }} --build-arg BITSTRING_VERSION=${{ inputs.bitstring-version }} --tag space-packet-parser-${{ inputs.python-version }}-test:latest
+    - name: Check out repo
+      uses: actions/checkout@v4
+    - name: Build test Docker image
+      run: docker build . --file Dockerfile --target test --build-arg BASE_IMAGE_PYTHON_VERSION=${{ inputs.python-version }} --build-arg BITSTRING_VERSION=${{ inputs.bitstring-version }} --tag space-packet-parser-${{ inputs.python-version }}-test:latest
     - name: Run Tests in Docker
       run: docker run -i space-packet-parser-${{ inputs.python-version }}-test:latest

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,9 +1,5 @@
 name: Test with Matrix of Python Versions
-on:
-  push:
-    branches: [ "main", "dev" ]
-  pull_request:
-    branches: [ "main", "dev" ]
+on: pull_request
 jobs:
   python-version-matrix:
     strategy:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # Python version with which to test (must be supported and available on dockerhub)
 ARG BASE_IMAGE_PYTHON_VERSION
 
-FROM python:${BASE_IMAGE_PYTHON_VERSION}-slim
+FROM python:${BASE_IMAGE_PYTHON_VERSION:-3.11}-slim AS test
 
 # Optional bitstring version
 ARG BITSTRING_VERSION
@@ -51,3 +51,8 @@ ENTRYPOINT pytest --cov-report=xml:coverage.xml \
     --cov=space_packet_parser \
     --junitxml=junit.xml \
     tests
+
+
+FROM test AS lint
+
+ENTRYPOINT pylint space_packet_parser


### PR DESCRIPTION
Change the default python version for our tests to Python 3.11 (overridden with BASE_IMAGE_PYTHON_VERSION)

# Title of PR

Brief description of changes. If you write good commit messages, put the concatenated list of messages here.


## Checklist
- [x] Changes are fully implemented without dangling issues or TODO items
- [x] Deprecated/superseded code is removed or marked with deprecation warning
- [x] Current dependencies have been properly specified and old dependencies removed
- [x] New code/functionality has accompanying tests and any old tests have been updated to match any new assumptions
- [NA] The changelog.md has been updated
