### PR TITLE
Add error handling for invalid/unknown parameter type

### DIFF
--- a/docs/source/changelog.md
+++ b/docs/source/changelog.md
@@ -5,8 +5,10 @@ list and release milestones.
 ## Version Release Notes
 Release notes for the `space_packet_parser` library
 
-### vXXX (unreleased)
+### v5.0.0 (unreleased)
+- Replace bitstring objects with native Python bytes objects (except for in CSV-based parsing code)
 - Fix EnumeratedParameterType to handle duplicate labels
+- Add error reporting for unsupported and invalid parameter types
 
 ### v4.2.0 (released)
 - Parse short and long descriptions of parameters
@@ -17,6 +19,7 @@ Release notes for the `space_packet_parser` library
 - Drop support for bitstring <4.0.1
 - Support BooleanExpression in a ContextCalibrator
 - Default read size is changed to a full file read on file-like objects
+- Improve error handling for invalid/unsupported parameter types
 
 ### v4.1.1 (released)
 - Allow Python 3.12

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,9 +1,12 @@
 """Test fixtures"""
-# Standard library
+# Standard
 from pathlib import Path
 import sys
-# External modules
+# Installed
 import pytest
+
+XTCE_URI = "http://www.omg.org/space/xtce"
+TEST_NAMESPACE = {'xtce': XTCE_URI}
 
 
 @pytest.fixture

--- a/tests/test_data/test_xtce.xml
+++ b/tests/test_data/test_xtce.xml
@@ -1,5 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<xtce:SpaceSystem xmlns:xtce="http://www.omg.org/space/xtce" name="Space Packet Parser">
+<xtce:SpaceSystem xmlns:xtce="http://www.omg.org/space/xtce" name="Space Packet Parser"
+                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                  xsi:schemaLocation="http://www.omg.org/spec/XTCE/20180204/SpaceSystem.xsd">
     <xtce:Header date="2024-03-05T13:36:00MST" version="1.0" author="Gavin Medley"/>
     <xtce:TelemetryMetaData>
         <xtce:ParameterTypeSet>


### PR DESCRIPTION
# Handle Errors for Unsupported/Invalid Parameter Types

- Add error handling for unknown and invalid parameter type element during XTCE parsing

## Checklist
- [x] Changes are fully implemented without dangling issues or TODO items
- [x] Deprecated/superseded code is removed or marked with deprecation warning
- [x] Current dependencies have been properly specified and old dependencies removed
- [x] New code/functionality has accompanying tests and any old tests have been updated to match any new assumptions
- [x] The changelog.md has been updated
