### PR TITLE
Fast forward 4.2.0 release changes back to main

### DIFF
--- a/.github/workflows/run-pylint.yml
+++ b/.github/workflows/run-pylint.yml
@@ -1,5 +1,5 @@
 name: Run Pylint
-on: [push, pull_request]
+on: pull_request
 jobs:
   pylint:
     runs-on: ubuntu-latest

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,7 +1,7 @@
 cff-version: 1.2.0
 title: 'space_packet_parser'
 type: software
-version: '4.1.1'
+version: '4.2.0'
 description: A CCSDS telemetry packet decoding library based on the XTCE packet format description standard.
 license: BSD-3-Clause
 abstract: The space_packet_parser Python library is a generalized, configurable packet decoding library for CCSDS telemetry

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,39 +1,50 @@
-version: '3'
+version: '3.8'
 
 services:
+  lint:
+    image: space-packets-linting:latest
+    build:
+      target: lint
+
   3.8-tests:
     image: space-packets-3.8-test:latest
     build:
+      target: test
       args:
         - BASE_IMAGE_PYTHON_VERSION=3.8
 
   3.9-tests:
     image: space-packets-3.9-test:latest
     build:
+      target: test
       args:
         - BASE_IMAGE_PYTHON_VERSION=3.9
 
   3.10-tests:
     image: space-packets-3.10-test:latest
     build:
+      target: test
       args:
         - BASE_IMAGE_PYTHON_VERSION=3.10
 
   3.11-tests:
     image: space-packets-3.11-test:latest
     build:
+      target: test
       args:
         - BASE_IMAGE_PYTHON_VERSION=3.11
 
   3.12-tests:
     image: space-packets-3.12-test:latest
     build:
+      target: test
       args:
         - BASE_IMAGE_PYTHON_VERSION=3.12
 
   3.11-tests-min-deps:
     image: space-packets-3.11-test:latest
     build:
+      target: test
       args:
         - BASE_IMAGE_PYTHON_VERSION=3.11
         - BITSTRING_VERSION=4.0.1

--- a/docs/source/changelog.md
+++ b/docs/source/changelog.md
@@ -1,15 +1,11 @@
 # Change Log
-This is a log of changes made to the library over time
-
-## Long Term To-Do List
-- Add frame transfer parsing layer on top of CCSDS parsing layer
-- Add ByteOrderList support to encodings in xtcedef (search for TODOs)
-- Support multiple `xtce:Unit` elements for compound units
+This is a log of changes made to the library over time. For planned upcoming changes, please check the GitHub issue 
+list and release milestones.
 
 ## Version Release Notes
 Release notes for the `space_packet_parser` library
 
-### v4.2.0 (unreleased)
+### v4.2.0 (released)
 - Parse short and long descriptions of parameters
 - Implement equality checking for SequenceContainer objects and Parameter objects
 - Include parameter short description and long description in ParsedDataItems

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "space_packet_parser"
-version = "4.1.1"
+version = "4.2.0"
 description = "A CCSDS telemetry packet decoding library based on the XTCE packet format description standard."
 license = "BSD-3-Clause"
 readme = "README.md"


### PR DESCRIPTION
# Post 4.2.0 release ffw merge back to main

Bump version in pyproject.toml and CITATION.cff
Mark 4.2.0 as released in preparation
Minor changelog updates
Add target option to docker-compose for local testing Add lint service in docker-compose for local linting
