### PR TITLE
ENH: Change parsing logic to bytes manipulation directly

### DIFF
--- a/space_packet_parser/xtcedef.py
+++ b/space_packet_parser/xtcedef.py
@@ -2590,14 +2590,15 @@ def _extract_bits(data: bytes, start_bit: int, nbits: int):
     # Get the bits from the packet data
     # Select the bytes that contain the bits we want
     start_byte = start_bit // 8
-    end_byte = start_byte + (nbits + 7) // 8
+    start_bit %= 8
+    end_byte = start_byte + (start_bit + nbits + 7) // 8
     data = data[start_byte:end_byte]
     # Convert the bytes to an integer for bitwise operations
     value = int.from_bytes(data, byteorder="big")
-    if start_bit % 8 == 0 and nbits % 8 == 0:
+    if start_bit == 0 and nbits % 8 == 0:
         # If we're extracting whole bytes, we don't need any bitshifting
         # This is faster, especially for large binary chunks
         return value
     # Shift the value to the right to get the start bit to the least significant position
     # Then mask out the bits we want to keep
-    return (value >> (len(data) * 8 - (start_bit % 8) - nbits)) & (2 ** nbits - 1)
+    return (value >> (len(data) * 8 - start_bit - nbits)) & (2 ** nbits - 1)

--- a/tests/unit/test_xtcedef.py
+++ b/tests/unit/test_xtcedef.py
@@ -1862,3 +1862,15 @@ def test_parsing_xtce_document(test_data_dir):
         abstract=True,
         inheritors=None
     )
+
+@pytest.mark.parametrize("start, nbits", [(0, 1), (0, 16), (0, 8), (0, 9),
+                                        (3, 5), (3, 8), (3, 13),
+                                        (7, 1), (7, 2), (7, 8),
+                                        (8, 1), (8, 8), (15, 1)])
+def test__extract_bits(start, nbits):
+    """Test the _extract_bits function with various start and nbits values"""
+    # Test extracting bits from a bitstream
+    s = '0000111100001111'
+    data = int(s, 2).to_bytes(2, byteorder="big")
+
+    assert xtcedef._extract_bits(data, start, nbits) == int(s[start:start+nbits], 2)


### PR DESCRIPTION
# Speed up parsing by removing bitstring reads

Avoid bitstring and do the bitwise reading and manipulations ourselves with bitwise logic. This greatly increases the performance of the parser by ~3-5x in the read routine. This is sort of the MVP for speed-ups by just implementing the routines we need and trying to replicate bitstring. We could do better by refactoring the `_get_format_string()` logic and avoiding any string matching/parsing/splitting too.

I did not fully remove bitstring at this point since there is a lot of logic surrounding it in `parser.py`. We could make it an optional dependency, but it would be nice to get rid of the `legacy_parse_packet()` method if we go that route. Happy to add that deprecation path here if it'd be useful, but probably a major version bump then.

### Profiling

**main**
![image](https://github.com/user-attachments/assets/b60941cb-48fb-492e-8d76-1de324052bfe)

**this branch**
![image](https://github.com/user-attachments/assets/25c32041-000e-40ef-9a99-01c2208742d5)


## Checklist
- [x] Changes are fully implemented without dangling issues or TODO items
- [ ] Deprecated/superseded code is removed or marked with deprecation warning
- [ ] Current dependencies have been properly specified and old dependencies removed
- [n/a] New code/functionality has accompanying tests and any old tests have been updated to match any new assumptions
- [ ] The changelog.md has been updated
