### PR TITLE
Add a Parseable Protocol and parse method

### DIFF
--- a/space_packet_parser/parser.py
+++ b/space_packet_parser/parser.py
@@ -83,10 +83,11 @@ class PacketParser:
         header = {}
         current_bit = 0
         for item in CCSDS_HEADER_DEFINITION:
-            header[item.name] = xtcedef.ParsedDataItem(name=item.name,
-                                               unit=None,
-                                               # pylint: disable=protected-access
-                                               raw_value=xtcedef._extract_bits(packet_data, current_bit, item.nbits))
+            header[item.name] = xtcedef.ParsedDataItem(
+                name=item.name,
+                unit=None,
+                # pylint: disable=protected-access
+                raw_value=xtcedef._extract_bits(packet_data, current_bit, item.nbits))
             current_bit += item.nbits
         return header
 

--- a/space_packet_parser/xtcedef.py
+++ b/space_packet_parser/xtcedef.py
@@ -83,15 +83,12 @@ class ParsedDataItem:
         Parameter long description
     """
     name: str
-    raw_value: Any
+    raw_value: Union[bytes, float, int, str]
     unit: Optional[str] = None
     derived_value: Optional[Union[float, str]] = None
     short_description: Optional[str] = None
     long_description: Optional[str] = None
 
-    def __post_init__(self):
-        if self.name is None or self.raw_value is None:
-            raise ValueError("ParsedDataItem must have a name and a raw value.")
 
 # Matching logical objects
 class MatchCriteria(AttrComparable, metaclass=ABCMeta):
@@ -2379,10 +2376,9 @@ class Parameter(Parseable):
     short_description: Optional[str] = None
     long_description: Optional[str] = None
 
-
     def parse(self, packet_data: PacketData, parsed_items: dict, **parse_value_kwargs) -> dict:
         """Parse this parameter from the packet data.
-        
+
         Create a ``ParsedDataItem`` and add it to the parsed_items dictionary.
         """
         parsed_value, derived_value = self.parameter_type.parse_value(
@@ -2427,24 +2423,24 @@ class SequenceContainer(Parseable):
     short_description: Optional[str] = None
     long_description: Optional[str] = None
     base_container_name: Optional[str] = None
-    restriction_criteria: Optional[list] = field(default_factory=lambda : [])
+    restriction_criteria: Optional[list] = field(default_factory=lambda: [])
     abstract: bool = False
-    inheritors: Optional[List['SequenceContainer']] = field(default_factory=lambda : [])
+    inheritors: Optional[List['SequenceContainer']] = field(default_factory=lambda: [])
 
     def __post_init__(self):
         # Handle the explicit None passing for default values
         self.restriction_criteria = self.restriction_criteria or []
         self.inheritors = self.inheritors or []
 
-
     def parse(self, packet_data: PacketData, parsed_items: dict, **parse_value_kwargs) -> dict:
         """Parse the entry list of parameters/containers in the order they are expected in the packet.
-        
+
         This could be recursive if the entry list contains SequenceContainers.
         """
         for entry in self.entry_list:
             parsed_items = entry.parse(packet_data=packet_data, parsed_items=parsed_items, **parse_value_kwargs)
         return parsed_items
+
 
 FlattenedContainer = namedtuple('FlattenedContainer', ['entry_list', 'restrictions'])
 

--- a/tests/unit/test_parser.py
+++ b/tests/unit/test_parser.py
@@ -16,8 +16,10 @@ from space_packet_parser import parser
 )
 def test_parsed_data_item(name, raw_value, unit, derived_value, short_description, long_description, valid):
     """Test ParsedDataItem"""
-    if valid:
-        pdi = parser.ParsedDataItem(name, raw_value, unit, derived_value, short_description, long_description)
-    else:
-        with pytest.raises(ValueError):
-            pdi = parser.ParsedDataItem(name, raw_value, unit, derived_value, short_description, long_description)
+    pdi = parser.ParsedDataItem(name, raw_value, unit, derived_value, short_description, long_description)
+    assert pdi.name == name
+    assert pdi.raw_value == raw_value
+    assert pdi.unit == unit
+    assert pdi.derived_value == derived_value
+    assert pdi.short_description == short_description
+    assert pdi.long_description == long_description


### PR DESCRIPTION
This enables the same call structure when parsing the data fields and easier pass-through. It is also faster in the hot-loop than using `isinstance()` to get the specific path to go down.

This builds upon the other two performance PRs as I'm whittling things down here and the calling type definitions change, so it was easier to test on top of everything. I can remove them if that would be helpful, but for review you can just look at the final commit here: 98491cec9df52926849aae7930c44b084812ec50

Changes:
* Added a `parse()` method to `SequenceContainer` and `Parameter` with the same call signature.
  * (Note that this is actually the same call signature as `parse_value()`, but with different return types. I'm wondering if there is actually a way to structure these all the same...)
* Moved `ParsedDataItem` into the `xtcedef` module as it is now needed for the `parse()` method. Also had to reimport into the `parser` module for backwards compatibility.
* Added a `Parseable` `Protocol`, not completely necessary, but seems like something nice to define.
* Changed to using dataclasses for the data structures. These automatically bring along the `AttrComparable`-like stuff and this cleaned up some of the init/repr things IMO. Again, not totally necessary, but I think it'd be nice to start removing some of the boilerplate code if we can.

## Checklist
- [x] Changes are fully implemented without dangling issues or TODO items
- [n/a] Deprecated/superseded code is removed or marked with deprecation warning
- [n/a] Current dependencies have been properly specified and old dependencies removed
- [n/a] New code/functionality has accompanying tests and any old tests have been updated to match any new assumptions
- [ ] The changelog.md has been updated
