### PR TITLE
FIX: Enumerated parameter lookup of duplicate labels

### DIFF
--- a/docs/source/changelog.md
+++ b/docs/source/changelog.md
@@ -5,6 +5,9 @@ list and release milestones.
 ## Version Release Notes
 Release notes for the `space_packet_parser` library
 
+### vXXX (unreleased)
+- Fix EnumeratedParameterType to handle duplicate labels
+
 ### v4.2.0 (released)
 - Parse short and long descriptions of parameters
 - Implement equality checking for SequenceContainer objects and Parameter objects

--- a/space_packet_parser/xtcedef.py
+++ b/space_packet_parser/xtcedef.py
@@ -1881,7 +1881,7 @@ class EnumeratedParameterType(ParameterType):
             raise ValueError("An EnumeratedParameterType must contain an EnumerationList.")
 
         return {
-            el.attrib['label']: int(el.attrib['value'])
+            int(el.attrib['value']): el.attrib['label']
             for el in enumeration_list.iterfind('xtce:Enumeration', ns)
         }
 
@@ -1907,8 +1907,8 @@ class EnumeratedParameterType(ParameterType):
         # Note: The enum lookup only operates on raw values. This is specified in 4.3.2.4.3.6 of the XTCE spec "
         # CCSDS 660.1-G-2
         try:
-            label = next(key for key, value in self.enumeration.items() if value == raw)
-        except StopIteration as exc:
+            label = self.enumeration[raw]
+        except KeyError as exc:
             raise ValueError(f"Failed to find raw value {raw} in enum lookup list {self.enumeration}.") from exc
         return raw, label
 

--- a/tests/unit/test_xtcedef.py
+++ b/tests/unit/test_xtcedef.py
@@ -1366,12 +1366,14 @@ def test_float_parameter_parsing(parameter_type, parsed_data, packet_data, expec
         <xtce:Enumeration label="BOOT_RETURN" value="1"/>
         <xtce:Enumeration label="OP_LOW" value="2"/>
         <xtce:Enumeration label="OP_HIGH" value="3"/>
+        <xtce:Enumeration label="OP_HIGH" value="4"/>
     </xtce:EnumerationList>
 </xtce:EnumeratedParameterType>
 """,
          xtcedef.EnumeratedParameterType(name='TEST_ENUM_Type',
                                          encoding=xtcedef.IntegerDataEncoding(size_in_bits=2, encoding='unsigned'),
-                                         enumeration={'BOOT_POR': 0, 'BOOT_RETURN': 1, 'OP_LOW': 2, 'OP_HIGH': 3})),
+                                         # NOTE: Duplicate final value is on purpose to make sure we handle that case
+                                         enumeration={0: 'BOOT_POR', 1: 'BOOT_RETURN', 2: 'OP_LOW', 3: 'OP_HIGH', 4: 'OP_HIGH'})),
     ]
 )
 def test_enumerated_parameter_type(xml_string: str, expectation):
@@ -1389,11 +1391,11 @@ def test_enumerated_parameter_type(xml_string: str, expectation):
 @pytest.mark.parametrize(
     ('parameter_type', 'parsed_data', 'packet_data', 'expected'),
     [
-        (xtcedef.EnumeratedParameterType('TEST_ENUM', xtcedef.IntegerDataEncoding(16, 'unsigned'), {'NOMINAL': 32768}),
+        (xtcedef.EnumeratedParameterType('TEST_ENUM', xtcedef.IntegerDataEncoding(16, 'unsigned'), {32768: 'NOMINAL'}),
          {}, '0b1000000000000000', 'NOMINAL'),
         (xtcedef.EnumeratedParameterType(
             'TEST_FLOAT',
-            xtcedef.IntegerDataEncoding(16, 'signed'),  {'VAL_LOW': -42}),
+            xtcedef.IntegerDataEncoding(16, 'signed'),  {-42: 'VAL_LOW'}),
          {}, '0b1111111111010110', 'VAL_LOW'),
     ]
 )


### PR DESCRIPTION
If an entry has duplicate labels for different raw values we need to lookup based on values rather than labels. The values are the unique piece of the enumeration, so swap the dictionary key/value storage.

## Checklist
- [x] Changes are fully implemented without dangling issues or TODO items
- [n/a] Deprecated/superseded code is removed or marked with deprecation warning
- [n/a] Current dependencies have been properly specified and old dependencies removed
- [x] New code/functionality has accompanying tests and any old tests have been updated to match any new assumptions
- [x] The changelog.md has been updated
