### PR TITLE
Fix Unit Tests Relying on ConstBitStream to use PacketData Instead

### DIFF
--- a/tests/unit/test_parser.py
+++ b/tests/unit/test_parser.py
@@ -1,6 +1,5 @@
 """Tests for space_packet_parser.parser"""
 # Installed
-import bitstring
 import pytest
 # Local
 from space_packet_parser import parser


### PR DESCRIPTION
# Fix Unit Tests Relying on ConstBitStream to use PacketData Instead

These tests were passing because the input data was a ConstBitStream which is still handled (until we rip it all out) so we weren't really testing the PacketData object's ability to parse data. 

- Update StringDataEncoding tests to use PacketData instead of ConstBitStream
- Add some more type-hinting throughout xtcedef.py
- Update unit tests for integer parsing using PacketData instead of ConstBitStream 
- Update float encoding unit tests to use PacketData 
- Update enumerated parameter type tests to use PacketData 
- Update binary parameter parsing test to use PacketData 
- Update boolean parameter parsing tests to use PacketData 
- Update time parameter type parsing tests to use PacketData instead of ConstBitStream

## Checklist
- [x] Changes are fully implemented without dangling issues or TODO items
- [x] Deprecated/superseded code is removed or marked with deprecation warning
- [x] Current dependencies have been properly specified and old dependencies removed
- [x] New code/functionality has accompanying tests and any old tests have been updated to match any new assumptions
- [ ] The changelog.md has been updated - I don't think we need to update the changelog for this.
