### PR TITLE
Remove bitstring dependency

### DIFF
--- a/.github/workflows/test-python-version.yml
+++ b/.github/workflows/test-python-version.yml
@@ -5,10 +5,6 @@ on:
       python-version:
         required: true
         type: string
-      bitstring-version:
-        required: false
-        type: string
-        default: ""
 jobs:
   test:
     name: Run Tests in Docker
@@ -18,6 +14,6 @@ jobs:
     - name: Check out repo
       uses: actions/checkout@v4
     - name: Build test Docker image
-      run: docker build . --file Dockerfile --target test --build-arg BASE_IMAGE_PYTHON_VERSION=${{ inputs.python-version }} --build-arg BITSTRING_VERSION=${{ inputs.bitstring-version }} --tag space-packet-parser-${{ inputs.python-version }}-test:latest
+      run: docker build . --file Dockerfile --target test --build-arg BASE_IMAGE_PYTHON_VERSION=${{ inputs.python-version }} --tag space-packet-parser-${{ inputs.python-version }}-test:latest
     - name: Run Tests in Docker
       run: docker run -i space-packet-parser-${{ inputs.python-version }}-test:latest

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,8 +5,6 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
-        bitstring-version: ["", "4.0.1", "4.1.4"]
     uses: ./.github/workflows/test-python-version.yml
     with:
       python-version: ${{ matrix.python-version }}
-      bitstring-version: ${{ matrix.bitstring-version }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,9 +3,6 @@ ARG BASE_IMAGE_PYTHON_VERSION
 
 FROM python:${BASE_IMAGE_PYTHON_VERSION:-3.11}-slim AS test
 
-# Optional bitstring version
-ARG BITSTRING_VERSION
-
 USER root
 
 ENV INSTALL_LOCATION=/opt/space_packet_parser
@@ -43,8 +40,6 @@ RUN pip install --upgrade pip
 
 # Install all dependencies (including dev deps) specified in pyproject.toml
 RUN poetry install
-
-RUN if [ -n "${BITSTRING_VERSION}" ]; then pip install bitstring==$BITSTRING_VERSION; fi
 
 ENTRYPOINT pytest --cov-report=xml:coverage.xml \
     --cov-report=term \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -47,4 +47,3 @@ services:
       target: test
       args:
         - BASE_IMAGE_PYTHON_VERSION=3.11
-        - BITSTRING_VERSION=4.0.1

--- a/docs/source/changelog.md
+++ b/docs/source/changelog.md
@@ -6,9 +6,11 @@ list and release milestones.
 Release notes for the `space_packet_parser` library
 
 ### v5.0.0 (unreleased)
-- Replace bitstring objects with native Python bytes objects
-  - Remove dependency on the bitstring library
+- BREAKING: Replace `bitstring` objects with native Python bytes objects
+  - Remove dependency on the `bitstring` library
   - Much faster parsing speed
+  - Users that are passing `bitstring.ConstBitStream` objects to `generator` will need to pass a 
+    binary filelike object instead
 - Fix EnumeratedParameterType to handle duplicate labels
 - Add error reporting for unsupported and invalid parameter types
 

--- a/docs/source/changelog.md
+++ b/docs/source/changelog.md
@@ -6,7 +6,9 @@ list and release milestones.
 Release notes for the `space_packet_parser` library
 
 ### v5.0.0 (unreleased)
-- Replace bitstring objects with native Python bytes objects (except for in CSV-based parsing code)
+- Replace bitstring objects with native Python bytes objects
+  - Remove dependency on the bitstring library
+  - Much faster parsing speed
 - Fix EnumeratedParameterType to handle duplicate labels
 - Add error reporting for unsupported and invalid parameter types
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,6 @@ keywords = [
 
 [tool.poetry.dependencies]
 python = ">=3.8"
-bitstring = ">=4.0.1"
 
 [tool.poetry.group.dev.dependencies]
 pylint = "*"

--- a/tests/integration/test_bufferedreader_parsing.py
+++ b/tests/integration/test_bufferedreader_parsing.py
@@ -1,6 +1,4 @@
 """Integration test for parsing JPSS packets"""
-# Installed
-import bitstring
 # Local
 from space_packet_parser import xtcedef
 from space_packet_parser import parser

--- a/tests/integration/test_csv_based_parsing/test_ctim_parsing.py
+++ b/tests/integration/test_csv_based_parsing/test_ctim_parsing.py
@@ -1,6 +1,4 @@
 """Test parsing of CTIM packet data"""
-# Installed
-import bitstring
 # Local
 from space_packet_parser import csvdef, parser
 
@@ -11,12 +9,10 @@ def test_csv_packet_definition_parsing(ctim_test_data_dir):
     csv_pkt_def = csvdef.CsvPacketDefinition(test_csv_file)
 
     test_packet_file = ctim_test_data_dir / 'ccsds_2021_155_14_39_51'
-    pkt_binary_data = bitstring.ConstBitStream(filename=test_packet_file)
-
     parser_inst = parser.PacketParser(csv_pkt_def)
-    pkt_gen = parser_inst.generator(pkt_binary_data, show_progress=True)
-
-    packets = list(pkt_gen)
+    with open(test_packet_file, 'rb') as pkt_file:
+        pkt_gen = parser_inst.generator(pkt_file, show_progress=True)
+        packets = list(pkt_gen)
 
     assert(len(packets) == 1499)
     assert(packets[159].header['PKT_APID'].raw_value == 34)

--- a/tests/integration/test_socket_parsing.py
+++ b/tests/integration/test_socket_parsing.py
@@ -5,7 +5,6 @@ import random
 import socket
 import time
 # Installed
-import bitstring
 import pytest
 
 # Local
@@ -25,19 +24,20 @@ def send_data(sender: socket.socket, file: str):
     """
     # Read binary file
     with open(file, 'rb') as fh:
-        stream = bitstring.ConstBitStream(fh)
-        while stream.pos < len(stream):
+        stream = fh.read()
+        pos = 0
+        while pos < len(stream):
             time.sleep(random.random() * .1)  # Random sleep up to 1s
             # Send binary data to socket in random chunk sizes
             min_n_bytes = 4096
             max_n_bytes = 4096*2
             random_n_bytes = int(random.random()) * (max_n_bytes - min_n_bytes)
-            n_bits_to_send = 8 * (min_n_bytes + random_n_bytes)
-            if stream.pos + n_bits_to_send > len(stream):
-                n_bits_to_send = len(stream) - stream.pos
-            chunk_to_send = stream[stream.pos:stream.pos + n_bits_to_send]
-            sender.send(chunk_to_send.bytes)
-            stream.pos += n_bits_to_send
+            n_bytes_to_send = 8 * (min_n_bytes + random_n_bytes)
+            if pos + n_bytes_to_send > len(stream):
+                n_bytes_to_send = len(stream) - pos
+            chunk_to_send = stream[pos:pos + n_bytes_to_send]
+            sender.send(chunk_to_send)
+            pos += n_bytes_to_send
         print("\nFinished sending data.")
 
 

--- a/tests/integration/test_xtce_based_parsing/test_inheritance_restrictions.py
+++ b/tests/integration/test_xtce_based_parsing/test_inheritance_restrictions.py
@@ -1,6 +1,4 @@
 """Test RestrictionCriteria being used creatively with JPSS data"""
-# Installed
-import bitstring
 # Local
 from space_packet_parser import xtcedef
 from space_packet_parser import parser

--- a/tests/integration/test_xtce_based_parsing/test_suda_parsing.py
+++ b/tests/integration/test_xtce_based_parsing/test_suda_parsing.py
@@ -3,8 +3,6 @@
 The packet definition used here is intended for IDEX, which is basically a rebuild of the SUDA instrument.
 The data used here is SUDA data but the fields are parsed using IDEX naming conventions.
 """
-# Installed
-import bitstring
 # Local
 from space_packet_parser import xtcedef
 from space_packet_parser import parser
@@ -12,21 +10,26 @@ from space_packet_parser import parser
 
 def parse_hg_waveform(waveform_raw: str):
     """Parse a binary string representing a high gain waveform"""
-    w = bitstring.ConstBitStream(bin=waveform_raw)
     ints = []
-    while w.pos < len(w):
-        w.read('bits:2')  # skip 2. We use bits instead of pad for bitstring 3.0.0 compatibility
-        ints += w.readlist(['uint:10']*3)
+    for i in range(0, len(waveform_raw), 32):
+        # 32 bit chunks, divided up into 2, 10, 10, 10
+        # skip first two bits
+        ints += [
+            int(waveform_raw[i + 2 : i + 12], 2),
+            int(waveform_raw[i + 12 : i + 22], 2),
+            int(waveform_raw[i + 22 : i + 32], 2),
+        ]
     return ints
 
 
 def parse_lg_waveform(waveform_raw: str):
     """Parse a binary string representing a low gain waveform"""
-    w = bitstring.ConstBitStream(bin=waveform_raw)
     ints = []
-    while w.pos < len(w):
-        w.read('bits:8')  # skip 2
-        ints += w.readlist(['uint:12']*2)
+    for i in range(0, len(waveform_raw), 32):
+        ints += [
+            int(waveform_raw[i + 8 : i + 20], 2),
+            int(waveform_raw[i + 20 : i + 32], 2),
+        ]
     return ints
 
 

--- a/tests/unit/test_csvdef.py
+++ b/tests/unit/test_csvdef.py
@@ -1,6 +1,4 @@
 """Tests for the CSV based packet definition"""
-# Installed
-import bitstring
 import pytest
 # Local
 from space_packet_parser import csvdef, xtcedef, parser
@@ -56,10 +54,8 @@ def test_csv_packet_definition(ctim_test_data_dir):
     assert isinstance(csv_pkt_def, CsvPacketDefinition)
 
     test_packet_file = ctim_test_data_dir / 'ccsds_2021_155_14_39_51'
-    pkt_binary_data = bitstring.ConstBitStream(filename=test_packet_file)
-
-    parser_inst = parser.PacketParser(csv_pkt_def)
-    pkt_gen = parser_inst.generator(pkt_binary_data)
-
-    packet = next(pkt_gen)
+    with open(test_packet_file, 'rb') as pkt_file:
+        parser_inst = parser.PacketParser(csv_pkt_def)
+        pkt_gen = parser_inst.generator(pkt_file, show_progress=True)
+        packet = next(pkt_gen)
     assert isinstance(packet, parser.Packet)


### PR DESCRIPTION
# Title of PR

This removes the bitstring dependency and all bitstring inputs allowed with it. You can pass in the raw objects instead of the bitstring objects now.

~~This also removes the `legacy_parser` method which was kept around to support csv parsing. This has been removed in favor of converting the csv packet definitions into the XTCE format instead.~~

This sits on top of https://github.com/medley56/space_packet_parser/pull/58 so there wasn't as much thrashing going on. Only the second commit is the removal portion.

~~NOTE: I have removed the entire csvdef module. I am not sure if you want to keep that around or not. This is definitely the heavy-handed approach of just removing all of the legacy things and moving on in a major version bump.~~

## Checklist
- [x] Changes are fully implemented without dangling issues or TODO items
- [x] Deprecated/superseded code is removed or marked with deprecation warning
- [x] Current dependencies have been properly specified and old dependencies removed
- [x] New code/functionality has accompanying tests and any old tests have been updated to match any new assumptions
- [x] The changelog.md has been updated
