### PR TITLE
FIX: Return the raw bytes from a BinaryDataEncoding

### DIFF
--- a/docs/source/changelog.md
+++ b/docs/source/changelog.md
@@ -11,6 +11,9 @@ Release notes for the `space_packet_parser` library
   - Much faster parsing speed
   - Users that are passing `bitstring.ConstBitStream` objects to `generator` will need to pass a 
     binary filelike object instead
+- BREAKING: The return type of BinaryDataEncoding is now the raw bytes.
+  To get the previous behavior you can convert the data to an integer and then format it as a binary string.
+  ``f"{int.from_bytes(data, byteorder="big"):0{len(data)*8}b}"``
 - Fix EnumeratedParameterType to handle duplicate labels
 - Add error reporting for unsupported and invalid parameter types
 

--- a/space_packet_parser/xtcedef.py
+++ b/space_packet_parser/xtcedef.py
@@ -1795,7 +1795,7 @@ class BinaryDataEncoding(DataEncoding):
 
         if self.linear_adjuster is not None:
             len_bits = self.linear_adjuster(len_bits)
-        return f"bin:{len_bits}"
+        return f"bytes:{len_bits//8}"
 
     def parse_value(self, packet_data: PacketData, parsed_data: dict, word_size: Optional[int] = None, **kwargs):
         """Parse a value from packet data, possibly using previously parsed data items to inform parsing.

--- a/tests/integration/test_xtce_based_parsing/test_suda_parsing.py
+++ b/tests/integration/test_xtce_based_parsing/test_suda_parsing.py
@@ -111,7 +111,9 @@ def test_suda_xtce_packet_parsing(suda_test_data_dir):
 
     # Parse the waveforms according to the scitype present (HG/LG channels encode waveform data differently)
     for scitype, waveform in data.items():
-        data[scitype] = parse_waveform_data(waveform, scitype)
+        # Convert the binary data to an integer so we can then convert it to a binary string
+        int_val = int.from_bytes(waveform, byteorder="big")
+        data[scitype] = parse_waveform_data(f"{int_val:0{len(waveform)*8}b}", scitype)
         print(f"{len(data[scitype])} points")
         mean = sum(data[scitype]) / len(data[scitype])
         print(f"mean value = {mean}")

--- a/tests/unit/test_xtcedef.py
+++ b/tests/unit/test_xtcedef.py
@@ -1704,7 +1704,7 @@ def test_binary_parameter_type(xml_string: str, expectation):
             xtcedef.BinaryDataEncoding(fixed_size_in_bits=16)),
          {},
          xtcedef.PacketData(0b0011010000110010010100110000000001001011000000000100100100000000.to_bytes(length=8, byteorder='big')),
-         '0011010000110010'),
+         b"42"),
         # discrete lookup list size
         (xtcedef.BinaryParameterType(
             'TEST_BIN',
@@ -1716,7 +1716,7 @@ def test_binary_parameter_type(xml_string: str, expectation):
             ], linear_adjuster=lambda x: 8*x)),
          {'P1': parser.ParsedDataItem('P1', 1, None, 7.4)},
          xtcedef.PacketData(0b0011010000110010010100110000000001001011000000000100100100000000.to_bytes(length=8, byteorder='big')),
-         '0011010000110010'),
+         b"42"),
         # dynamic size reference to other parameter
         (xtcedef.BinaryParameterType(
             'TEST_BIN',
@@ -1724,7 +1724,7 @@ def test_binary_parameter_type(xml_string: str, expectation):
                                        use_calibrated_value=False, linear_adjuster=lambda x: 8*x)),
          {'BIN_LEN': parser.ParsedDataItem('BIN_LEN', 2, None)},
          xtcedef.PacketData(0b0011010000110010010100110000000001001011000000000100100100000000.to_bytes(length=8, byteorder='big')),
-         '0011010000110010'),
+         b"42"),
     ]
 )
 def test_binary_parameter_parsing(parameter_type, parsed_data, packet_data, expected):
@@ -1796,7 +1796,7 @@ def test_boolean_parameter_type(xml_string, expectation):
             xtcedef.BinaryDataEncoding(fixed_size_in_bits=1)),
          {},
          xtcedef.PacketData(0b0011010000110010010100110000000001001011000000000100100100000000.to_bytes(length=64, byteorder='big')),
-         '0', True),
+         b'', False),
         (xtcedef.BooleanParameterType(
             'TEST_BOOL',
             xtcedef.StringDataEncoding(encoding="UTF-8", termination_character='00')),


### PR DESCRIPTION
When dealing with binary data, users generally want the most raw data which is the bytes directly rather than a string representation of the bits. This is a breaking change and if users want to get the binary string, they can format the string output themselves now.

# Title of PR

Brief description of changes. If you write good commit messages, put the concatenated list of messages here.


## Checklist
- [x] Changes are fully implemented without dangling issues or TODO items
- [x] Deprecated/superseded code is removed or marked with deprecation warning
- [x] Current dependencies have been properly specified and old dependencies removed
- [x] New code/functionality has accompanying tests and any old tests have been updated to match any new assumptions
- [x] The changelog.md has been updated
