### PR TITLE
Faster value parsing

### DIFF
--- a/tests/unit/test_xtcedef.py
+++ b/tests/unit/test_xtcedef.py
@@ -1523,7 +1523,7 @@ def test_float_parameter_type(xml_string: str, expectation):
             'TEST_FLOAT',
             xtcedef.FloatDataEncoding(32, byte_order='leastSignificantByteFirst')),
          {},
-         xtcedef.PacketData(0b01000000010010010000111111010000.to_bytes(length=4, byteorder='big')),
+         xtcedef.PacketData(0b01000000010010010000111111010000.to_bytes(length=4, byteorder='little')),
          3.14159),
         # Test big endian 64-bit float
         (xtcedef.FloatParameterType('TEST_FLOAT', xtcedef.FloatDataEncoding(64)),
@@ -1704,7 +1704,7 @@ def test_binary_parameter_type(xml_string: str, expectation):
             xtcedef.BinaryDataEncoding(fixed_size_in_bits=16)),
          {},
          xtcedef.PacketData(0b0011010000110010010100110000000001001011000000000100100100000000.to_bytes(length=8, byteorder='big')),
-         b"42"),
+         b'42'),
         # discrete lookup list size
         (xtcedef.BinaryParameterType(
             'TEST_BIN',
@@ -1716,7 +1716,7 @@ def test_binary_parameter_type(xml_string: str, expectation):
             ], linear_adjuster=lambda x: 8*x)),
          {'P1': parser.ParsedDataItem('P1', 1, None, 7.4)},
          xtcedef.PacketData(0b0011010000110010010100110000000001001011000000000100100100000000.to_bytes(length=8, byteorder='big')),
-         b"42"),
+         b'42'),
         # dynamic size reference to other parameter
         (xtcedef.BinaryParameterType(
             'TEST_BIN',
@@ -1724,7 +1724,7 @@ def test_binary_parameter_type(xml_string: str, expectation):
                                        use_calibrated_value=False, linear_adjuster=lambda x: 8*x)),
          {'BIN_LEN': parser.ParsedDataItem('BIN_LEN', 2, None)},
          xtcedef.PacketData(0b0011010000110010010100110000000001001011000000000100100100000000.to_bytes(length=8, byteorder='big')),
-         b"42"),
+         b'42'),
     ]
 )
 def test_binary_parameter_parsing(parameter_type, parsed_data, packet_data, expected):
@@ -1796,7 +1796,7 @@ def test_boolean_parameter_type(xml_string, expectation):
             xtcedef.BinaryDataEncoding(fixed_size_in_bits=1)),
          {},
          xtcedef.PacketData(0b0011010000110010010100110000000001001011000000000100100100000000.to_bytes(length=64, byteorder='big')),
-         b'', False),
+         b'\x00', True),
         (xtcedef.BooleanParameterType(
             'TEST_BOOL',
             xtcedef.StringDataEncoding(encoding="UTF-8", termination_character='00')),


### PR DESCRIPTION
This is a proof of concept PR for now, building on top of the little-endian PR to reduce the thrashing when rebasing, so only the last commit is relevant. It is currently failing one test because of the binary-bytes transition that would make this PR easier as well.

I get 5.2s with this PR, vs 6.6s from main, so a pretty significant speed-up.

The major changes are:
- Move some parameter instantiation logic up into the init routines rather than in the hot-loop reading packets.
- Make a `read_bytes` and `read_int` method on `PacketData` for the two explicit cases of wanting to get data without having to convert between the two so frequently.
- Move the if-branches from the `read()` method up into their respective data encodings so that we limit the number of checks needed when returning the parsed data.

### TODO

~~Remove `PacketData.read()` / `PacketData.peek()` methods once the string refactor work goes in.~~

**Question:**
Do we want to make the `DataEncoding` parsing a standard workflow? Something like the following:
```python
def parse_value(...):
    self._calculate_size()
    self._get_raw_value()
    self._calibrate_value()
```

where each subclass could override those specific functions rather than `parse_value()` directly. For example, `StringDataEncoding` wouldn't need a `calibrate_value()` because there are no calibrators, so it could be a no-op there. Currently, we are doing something similar with `get_bitstring_format()`, but there are differing amounts of logic in each subclass location and wondering if it'd make sense to expand into a few different routines instead.

closes #57


## Checklist
- [ ] Changes are fully implemented without dangling issues or TODO items
- [n/a] Deprecated/superseded code is removed or marked with deprecation warning
- [n/a] Current dependencies have been properly specified and old dependencies removed
- [x] New code/functionality has accompanying tests and any old tests have been updated to match any new assumptions
- [n/a] The changelog.md has been updated
