### PR TITLE
Unify packet class

### DIFF
--- a/docs/source/changelog.md
+++ b/docs/source/changelog.md
@@ -13,7 +13,7 @@ Release notes for the `space_packet_parser` library
     binary filelike object instead
 - BREAKING: The return type of BinaryDataEncoding is now the raw bytes.
   To get the previous behavior you can convert the data to an integer and then format it as a binary string.
-  ``f"{int.from_bytes(data, byteorder="big"):0{len(data)*8}b}"``
+  ``f"{int.from_bytes(data, byteorder='big'):0{len(data)*8}b}"``
 - Fix EnumeratedParameterType to handle duplicate labels
 - Add error reporting for unsupported and invalid parameter types
 

--- a/examples/parsing_and_plotting_idex_waveforms_from_socket.py
+++ b/examples/parsing_and_plotting_idex_waveforms_from_socket.py
@@ -76,13 +76,14 @@ def parse_lg_waveform(waveform_raw: str):
     return ints
 
 
-def parse_waveform_data(waveform: str, scitype: int):
+def parse_waveform_data(waveform: bytes, scitype: int):
     """Parse the binary string that represents a waveform"""
     print(f'Parsing waveform for scitype={scitype}')
+    waveform_str = f"{int.from_bytes(waveform, byteorder='big'):0{len(waveform)*8}b}"
     if scitype in (2, 4, 8):
-        return parse_hg_waveform(waveform)
+        return parse_hg_waveform(waveform_str)
     else:
-        return parse_lg_waveform(waveform)
+        return parse_lg_waveform(waveform_str)
 
 
 def plot_full_event(data: dict):

--- a/tests/unit/test_csvdef.py
+++ b/tests/unit/test_csvdef.py
@@ -58,4 +58,4 @@ def test_csv_packet_definition(ctim_test_data_dir):
         parser_inst = parser.PacketParser(csv_pkt_def)
         pkt_gen = parser_inst.generator(pkt_file, show_progress=True)
         packet = next(pkt_gen)
-    assert isinstance(packet, parser.Packet)
+    assert isinstance(packet, xtcedef.Packet)

--- a/tests/unit/test_xtcedef.py
+++ b/tests/unit/test_xtcedef.py
@@ -1130,16 +1130,15 @@ def test_string_parameter_type(xml_string: str, expectation):
 
 
 @pytest.mark.parametrize(
-    ('parameter_type', 'parsed_data', 'packet_data', 'expected'),
+    ('parameter_type', 'packet', 'expected'),
     [
         # Fixed length test
         (xtcedef.StringParameterType(
             'TEST_STRING',
             xtcedef.StringDataEncoding(fixed_length=3,  # Giving length in bytes
                                        length_linear_adjuster=lambda x: 8*x)),
-         {},  # Don't need parsed_data for leading length parsing
          # This still 123X456
-         xtcedef.PacketData(b'123X456'),
+         xtcedef.Packet(b'123X456'),
          '123'),
         # Dynamic reference length
         (xtcedef.StringParameterType(
@@ -1147,8 +1146,8 @@ def test_string_parameter_type(xml_string: str, expectation):
             xtcedef.StringDataEncoding(dynamic_length_reference='STR_LEN',
                                        use_calibrated_value=False,
                                        length_linear_adjuster=lambda x: 8*x)),
-         {'STR_LEN': parser.ParsedDataItem('STR_LEN', 8, None)},
-         xtcedef.PacketData(b'BAD WOLF'),
+         xtcedef.Packet(b'BAD WOLF', parsed_data={
+             'STR_LEN': parser.ParsedDataItem('STR_LEN', 8, None)}),
          'BAD WOLF'),
         # Discrete lookup test
         (xtcedef.StringParameterType(
@@ -1159,78 +1158,70 @@ def test_string_parameter_type(xml_string: str, expectation):
                     xtcedef.Comparison(99, 'P2', '==', use_calibrated_value=False)
                 ], lookup_value=8)
             ], length_linear_adjuster=lambda x: 8*x)),
-         {'P1': parser.ParsedDataItem('P1', 7, None, 7.55), 'P2': parser.ParsedDataItem('P2', 99, None, 100)},
-         xtcedef.PacketData(b'BAD WOLF'),
+         xtcedef.Packet(b'BAD WOLF', parsed_data={
+             'P1': parser.ParsedDataItem('P1', 7, None, 7.55), 'P2': parser.ParsedDataItem('P2', 99, None, 100)},),
          'BAD WOLF'),
         # Termination character tests
         (xtcedef.StringParameterType(
             'TEST_STRING',
             xtcedef.StringDataEncoding(encoding='UTF-8',
                                        termination_character='58')),
-         {},  # Don't need parsed_data for termination character
          # 123X456 + extra characters, termination character is X
-         xtcedef.PacketData(b'123X456000000000000000000000000000000000000000000000'),
+         xtcedef.Packet(b'123X456000000000000000000000000000000000000000000000'),
          '123'),
         (xtcedef.StringParameterType(
             'TEST_STRING',
             xtcedef.StringDataEncoding(encoding='UTF-8',
                                        termination_character='58')),
-         {},  # Don't need parsed_data for termination character
          # 56bits + 123X456 + extra characters, termination character is X
-         xtcedef.PacketData(b'9090909123X456000000000000000000000000000000000000000000000', pos=56),
+         xtcedef.Packet(b'9090909123X456000000000000000000000000000000000000000000000', pos=56),
          '123'),
         (xtcedef.StringParameterType(
             'TEST_STRING',
             xtcedef.StringDataEncoding(encoding='UTF-8',
                                        termination_character='58')),
-         {},  # Don't need parsed_data for termination character
          # 53bits + 123X456 + extra characters, termination character is X
          # This is the same string as above but bit-shifted left by 3 bits
-         xtcedef.PacketData(b'\x03K;s{\x93)\x89\x91\x9a\xc1\xa1\xa9\xb3K;s{\x93(', pos=53),
+         xtcedef.Packet(b'\x03K;s{\x93)\x89\x91\x9a\xc1\xa1\xa9\xb3K;s{\x93(', pos=53),
          '123'),
         (xtcedef.StringParameterType(
             "TEST_STRING",
             xtcedef.StringDataEncoding(encoding="UTF-8",
                                        termination_character='00')),
-         {},
-         xtcedef.PacketData("false_is_truthy".encode("UTF-8") + b'\x00ABCD'),
+         xtcedef.Packet("false_is_truthy".encode("UTF-8") + b'\x00ABCD'),
          'false_is_truthy'),
         (xtcedef.StringParameterType(
             "TEST_STRING",
             xtcedef.StringDataEncoding(encoding="UTF-16BE",
                                        termination_character='0021')),
-         {},
-         xtcedef.PacketData("false_is_truthy".encode("UTF-16BE") + b'\x00\x21ignoreme'),
+         xtcedef.Packet("false_is_truthy".encode("UTF-16BE") + b'\x00\x21ignoreme'),
          'false_is_truthy'),
         (xtcedef.StringParameterType(
             'TEST_STRING',
             xtcedef.StringDataEncoding(encoding='UTF-16LE',
                                        termination_character='5800')),
-         {},  # Don't need parsed_data for termination character
          # 123X456, termination character is X
-         xtcedef.PacketData('123X456'.encode('UTF-16LE')),
+         xtcedef.Packet('123X456'.encode('UTF-16LE')),
          '123'),
         (xtcedef.StringParameterType(
             'TEST_STRING',
             xtcedef.StringDataEncoding(encoding='UTF-16BE',
                                        termination_character='0058')),
-         {},  # Don't need parsed_data for termination character
-         xtcedef.PacketData('123X456'.encode('UTF-16BE')),
+         xtcedef.Packet('123X456'.encode('UTF-16BE')),
          '123'),
         # Leading length test
         (xtcedef.StringParameterType(
             'TEST_STRING',
             xtcedef.StringDataEncoding(leading_length_size=5)),
-         {},  # Don't need parsed_data for leading length parsing
          # This is still 123X456 but with 11000 prepended (a 5-bit representation of the number 24)
          # This represents a string length (in bits) of 24 bits.
-         xtcedef.PacketData(0b1100000110001001100100011001101011000001101000011010100110110000.to_bytes(8, byteorder="big")),
+         xtcedef.Packet(0b1100000110001001100100011001101011000001101000011010100110110000.to_bytes(8, byteorder="big")),
          '123'),
     ]
 )
-def test_string_parameter_parsing(parameter_type, parsed_data, packet_data, expected):
+def test_string_parameter_parsing(parameter_type, packet, expected):
     """Test parsing a string parameter"""
-    raw, _ = parameter_type.parse_value(packet_data, parsed_data)
+    raw, _ = parameter_type.parse_value(packet)
     assert raw == expected
 
 
@@ -1314,31 +1305,27 @@ def test_integer_parameter_type(xml_string: str, expectation):
 
 
 @pytest.mark.parametrize(
-    ('parameter_type', 'parsed_data', 'packet_data', 'expected'),
+    ('parameter_type', 'packet', 'expected'),
     [
         # 16-bit unsigned starting at byte boundary
         (xtcedef.IntegerParameterType('TEST_INT', xtcedef.IntegerDataEncoding(16, 'unsigned')),
-         {},
-         xtcedef.PacketData(0b1000000000000000.to_bytes(length=2, byteorder='big')),
+         xtcedef.Packet(0b1000000000000000.to_bytes(length=2, byteorder='big')),
          32768),
         # 16-bit unsigned little endian at byte boundary
         (xtcedef.IntegerParameterType(
             'TEST_INT',
             xtcedef.IntegerDataEncoding(16, 'unsigned', byte_order="leastSignificantByteFirst")),
-         {},
-         xtcedef.PacketData(0b1000000000000000.to_bytes(length=2, byteorder='big')),
+         xtcedef.Packet(0b1000000000000000.to_bytes(length=2, byteorder='big')),
          128),
         # 16-bit signed starting at byte boundary
         (xtcedef.IntegerParameterType('TEST_INT', xtcedef.IntegerDataEncoding(16, 'signed')),
-         {},
-         xtcedef.PacketData(0b1111111111010110.to_bytes(length=2, byteorder='big')),
+         xtcedef.Packet(0b1111111111010110.to_bytes(length=2, byteorder='big')),
          -42),
         # 16-bit signed little endian starting at byte boundary
         (xtcedef.IntegerParameterType(
             'TEST_INT',
             xtcedef.IntegerDataEncoding(16, 'signed', byte_order="leastSignificantByteFirst")),
-         {},
-         xtcedef.PacketData(0b1101011011111111.to_bytes(length=2, byteorder='big')),
+         xtcedef.Packet(0b1101011011111111.to_bytes(length=2, byteorder='big')),
          -42),
         # 16-bit signed integer starting at a byte boundary,
         # calibrated by a polynomial y = (x*2 + 5); x = -42; y = -84 + 5 = -79
@@ -1354,67 +1341,60 @@ def test_integer_parameter_type(xml_string: str, expectation):
                         xtcedef.PolynomialCalibrator([xtcedef.PolynomialCoefficient(5, 0),
                                                       xtcedef.PolynomialCoefficient(2, 1)]))
                 ])),
-         {'PKT_APID': parser.ParsedDataItem('PKT_APID', 1101)},
-         xtcedef.PacketData(0b1111111111010110.to_bytes(length=2, byteorder='big')),
+         xtcedef.Packet(0b1111111111010110.to_bytes(length=2, byteorder='big'),
+                            parsed_data={'PKT_APID': parser.ParsedDataItem('PKT_APID', 1101)},),
          -79),
         # 12-bit unsigned integer starting at bit 4 of the first byte
         (xtcedef.IntegerParameterType('TEST_INT', xtcedef.IntegerDataEncoding(12, 'unsigned')),
-         {},
          # 11111000 00000000
          #     |--uint:12--|
-         xtcedef.PacketData(0b1111100000000000.to_bytes(length=2, byteorder='big'), pos=4),
+         xtcedef.Packet(0b1111100000000000.to_bytes(length=2, byteorder='big'), pos=4),
          2048),
         # 13-bit unsigned integer starting on bit 2 of the second byte
         (xtcedef.IntegerParameterType('TEST_INT', xtcedef.IntegerDataEncoding(13, 'unsigned')),
-         {},
          # 10101010 11100000 00000001
          #            |--uint:13---|
-         xtcedef.PacketData(0b101010101110000000000001.to_bytes(length=3, byteorder='big'), pos=10),
+         xtcedef.Packet(0b101010101110000000000001.to_bytes(length=3, byteorder='big'), pos=10),
          4096),
         # 16-bit unsigned integer starting on bit 2 of the first byte
         (xtcedef.IntegerParameterType('TEST_INT', xtcedef.IntegerDataEncoding(16, 'unsigned')),
-         {},
          # 10101010 11100000 00000001
          #   |----uint:16-----|
-         xtcedef.PacketData(0b101010101110000000000001.to_bytes(length=3, byteorder='big'), pos=2),
+         xtcedef.Packet(0b101010101110000000000001.to_bytes(length=3, byteorder='big'), pos=2),
          43904),
         # 12-bit signed integer starting on bit 4 of the first byte
         (xtcedef.IntegerParameterType('TEST_INT', xtcedef.IntegerDataEncoding(12, 'signed')),
-         {},
          # 11111000 00000000
          #     |---int:12--|
-         xtcedef.PacketData(0b1111100000000000.to_bytes(length=2, byteorder='big'), pos=4),
+         xtcedef.Packet(0b1111100000000000.to_bytes(length=2, byteorder='big'), pos=4),
          -2048),
         # 12-bit signed integer starting on bit 6 of the first byte
         (xtcedef.IntegerParameterType('TEST_INT', xtcedef.IntegerDataEncoding(12, 'signed')),
-         {},
          # 12-bit signed integer starting on bit 4 of the first byte
          #  11111110 00000000 00111111 10101010
          #        |---int:12---|
-         xtcedef.PacketData(0b11111110000000000011111110101010.to_bytes(length=4, byteorder='big'), pos=6),
+         xtcedef.Packet(0b11111110000000000011111110101010.to_bytes(length=4, byteorder='big'), pos=6),
          -2048),
         # 12-bit signed little endian integer starting on bit 6 of the first byte
         (xtcedef.IntegerParameterType(
             'TEST_INT',
             xtcedef.IntegerDataEncoding(12, 'signed', byte_order='leastSignificantByteFirst')),
-         {},
          # 12-bit signed little endian integer starting on bit 4 of the first byte. The LSB of the integer comes first
          #  11111100 00000010 00111111 10101010
          #        |---int:12---|
-         xtcedef.PacketData(0b11111100000000100011111110101010.to_bytes(length=4, byteorder='big'), pos=6),
+         xtcedef.Packet(0b11111100000000100011111110101010.to_bytes(length=4, byteorder='big'), pos=6),
          -2048),
         (xtcedef.IntegerParameterType('TEST_INT', xtcedef.IntegerDataEncoding(3, 'twosComplement')),
-         {},
          # 3-bit signed integer starting at bit 7 of the first byte
          #  00000001      11000000       00000000
          #         |-int:3-|
-         xtcedef.PacketData(0b000000011100000000000000.to_bytes(length=3, byteorder='big'), pos=7),
+         xtcedef.Packet(0b000000011100000000000000.to_bytes(length=3, byteorder='big'), pos=7),
          -1),
     ]
 )
-def test_integer_parameter_parsing(parameter_type, parsed_data, packet_data, expected):
+def test_integer_parameter_parsing(parameter_type, packet, expected):
     """Testing parsing an integer parameters"""
-    raw, derived = parameter_type.parse_value(packet_data, parsed_data)
+    raw, derived = parameter_type.parse_value(packet)
     if derived:
         assert derived == expected
     else:
@@ -1511,24 +1491,21 @@ def test_float_parameter_type(xml_string: str, expectation):
 
 
 @pytest.mark.parametrize(
-    ('parameter_type', 'parsed_data', 'packet_data', 'expected'),
+    ('parameter_type', 'packet', 'expected'),
     [
         # Test big endion 32-bit IEEE float
         (xtcedef.FloatParameterType('TEST_FLOAT', xtcedef.FloatDataEncoding(32)),
-         {},
-         xtcedef.PacketData(0b01000000010010010000111111010000.to_bytes(length=4, byteorder='big')),
+         xtcedef.Packet(0b01000000010010010000111111010000.to_bytes(length=4, byteorder='big')),
          3.14159),
         # Test little endian 32-bit IEEE float
         (xtcedef.FloatParameterType(
             'TEST_FLOAT',
             xtcedef.FloatDataEncoding(32, byte_order='leastSignificantByteFirst')),
-         {},
-         xtcedef.PacketData(0b01000000010010010000111111010000.to_bytes(length=4, byteorder='little')),
+         xtcedef.Packet(0b01000000010010010000111111010000.to_bytes(length=4, byteorder='little')),
          3.14159),
         # Test big endian 64-bit float
         (xtcedef.FloatParameterType('TEST_FLOAT', xtcedef.FloatDataEncoding(64)),
-         {},
-         xtcedef.PacketData(b'\x3F\xF9\xE3\x77\x9B\x97\xF4\xA8'),  # 64-bit IEEE 754 value of Phi
+         xtcedef.Packet(b'\x3F\xF9\xE3\x77\x9B\x97\xF4\xA8'),  # 64-bit IEEE 754 value of Phi
          1.61803),
         # Test float parameter type encoded as big endian 16-bit integer with contextual polynomial calibrator
         (xtcedef.FloatParameterType(
@@ -1543,14 +1520,14 @@ def test_float_parameter_type(xml_string: str, expectation):
                         xtcedef.PolynomialCalibrator([xtcedef.PolynomialCoefficient(5.6, 0),
                                                       xtcedef.PolynomialCoefficient(2.1, 1)]))
                 ])),
-         {'PKT_APID': parser.ParsedDataItem('PKT_APID', 1101)},
-         xtcedef.PacketData(0b1111111111010110.to_bytes(length=2, byteorder='big')),
+         xtcedef.Packet(0b1111111111010110.to_bytes(length=2, byteorder='big'),
+                            parsed_data={'PKT_APID': parser.ParsedDataItem('PKT_APID', 1101)}),
          -82.600000),
     ]
 )
-def test_float_parameter_parsing(parameter_type, parsed_data, packet_data, expected):
+def test_float_parameter_parsing(parameter_type, packet, expected):
     """Test parsing float parameters"""
-    raw, derived = parameter_type.parse_value(packet_data, parsed_data)
+    raw, derived = parameter_type.parse_value(packet)
     if derived:
         # NOTE: These results are rounded due to the imprecise storage of floats
         assert round(derived, 5) == expected
@@ -1593,25 +1570,23 @@ def test_enumerated_parameter_type(xml_string: str, expectation):
 
 
 @pytest.mark.parametrize(
-    ('parameter_type', 'parsed_data', 'packet_data', 'expected'),
+    ('parameter_type', 'packet', 'expected'),
     [
         (xtcedef.EnumeratedParameterType(
             'TEST_ENUM',
             xtcedef.IntegerDataEncoding(16, 'unsigned'), {32768: 'NOMINAL'}),
-         {},
-         xtcedef.PacketData(0b1000000000000000.to_bytes(length=2, byteorder='big')),
+         xtcedef.Packet(0b1000000000000000.to_bytes(length=2, byteorder='big')),
          'NOMINAL'),
         (xtcedef.EnumeratedParameterType(
             'TEST_FLOAT',
             xtcedef.IntegerDataEncoding(16, 'signed'),  {-42: 'VAL_LOW'}),
-         {},
-         xtcedef.PacketData(0b1111111111010110.to_bytes(length=2, byteorder='big')),
+         xtcedef.Packet(0b1111111111010110.to_bytes(length=2, byteorder='big')),
          'VAL_LOW'),
     ]
 )
-def test_enumerated_parameter_parsing(parameter_type, parsed_data, packet_data, expected):
+def test_enumerated_parameter_parsing(parameter_type, packet, expected):
     """"Test parsing enumerated parameters"""
-    raw, derived = parameter_type.parse_value(packet_data, parsed_data)
+    raw, derived = parameter_type.parse_value(packet)
     if derived:
         # NOTE: These results are rounded due to the imprecise storage of floats
         assert derived == expected
@@ -1696,14 +1671,13 @@ def test_binary_parameter_type(xml_string: str, expectation):
 
 
 @pytest.mark.parametrize(
-    ('parameter_type', 'parsed_data', 'packet_data', 'expected'),
+    ('parameter_type', 'packet', 'expected'),
     [
         # fixed size
         (xtcedef.BinaryParameterType(
             'TEST_BIN',
             xtcedef.BinaryDataEncoding(fixed_size_in_bits=16)),
-         {},
-         xtcedef.PacketData(0b0011010000110010010100110000000001001011000000000100100100000000.to_bytes(length=8, byteorder='big')),
+         xtcedef.Packet(0b0011010000110010010100110000000001001011000000000100100100000000.to_bytes(length=8, byteorder='big')),
          b'42'),
         # discrete lookup list size
         (xtcedef.BinaryParameterType(
@@ -1714,22 +1688,22 @@ def test_binary_parameter_type(xml_string: str, expectation):
                                        operator='==', use_calibrated_value=True)
                 ], lookup_value=2)
             ], linear_adjuster=lambda x: 8*x)),
-         {'P1': parser.ParsedDataItem('P1', 1, None, 7.4)},
-         xtcedef.PacketData(0b0011010000110010010100110000000001001011000000000100100100000000.to_bytes(length=8, byteorder='big')),
+         xtcedef.Packet(0b0011010000110010010100110000000001001011000000000100100100000000.to_bytes(length=8, byteorder='big'),
+                            parsed_data={'P1': parser.ParsedDataItem('P1', 1, None, 7.4)}),
          b'42'),
         # dynamic size reference to other parameter
         (xtcedef.BinaryParameterType(
             'TEST_BIN',
             xtcedef.BinaryDataEncoding(size_reference_parameter='BIN_LEN',
                                        use_calibrated_value=False, linear_adjuster=lambda x: 8*x)),
-         {'BIN_LEN': parser.ParsedDataItem('BIN_LEN', 2, None)},
-         xtcedef.PacketData(0b0011010000110010010100110000000001001011000000000100100100000000.to_bytes(length=8, byteorder='big')),
+         xtcedef.Packet(0b0011010000110010010100110000000001001011000000000100100100000000.to_bytes(length=8, byteorder='big'),
+                            parsed_data={'BIN_LEN': parser.ParsedDataItem('BIN_LEN', 2, None)}),
          b'42'),
     ]
 )
-def test_binary_parameter_parsing(parameter_type, parsed_data, packet_data, expected):
+def test_binary_parameter_parsing(parameter_type, packet, expected):
     """Test parsing binary parameters"""
-    raw, _ = parameter_type.parse_value(packet_data, parsed_data)
+    raw, _ = parameter_type.parse_value(packet)
     assert raw == expected
 
 
@@ -1789,49 +1763,43 @@ def test_boolean_parameter_type(xml_string, expectation):
 
 
 @pytest.mark.parametrize(
-    ('parameter_type', 'parsed_data', 'packet_data', 'expected_raw', 'expected_derived'),
+    ('parameter_type', 'packet', 'expected_raw', 'expected_derived'),
     [
         (xtcedef.BooleanParameterType(
             'TEST_BOOL',
             xtcedef.BinaryDataEncoding(fixed_size_in_bits=1)),
-         {},
-         xtcedef.PacketData(0b0011010000110010010100110000000001001011000000000100100100000000.to_bytes(length=64, byteorder='big')),
+         xtcedef.Packet(0b0011010000110010010100110000000001001011000000000100100100000000.to_bytes(length=64, byteorder='big')),
          b'\x00', True),
         (xtcedef.BooleanParameterType(
             'TEST_BOOL',
             xtcedef.StringDataEncoding(encoding="UTF-8", termination_character='00')),
-         {},
-         xtcedef.PacketData(0b011001100110000101101100011100110110010101011111011010010111001101011111011101000111001001110101011101000110100001111001000000000010101101010111.to_bytes(length=18, byteorder='big')),
+         xtcedef.Packet(0b011001100110000101101100011100110110010101011111011010010111001101011111011101000111001001110101011101000110100001111001000000000010101101010111.to_bytes(length=18, byteorder='big')),
          'false_is_truthy', True),
         (xtcedef.BooleanParameterType(
             'TEST_BOOL',
             xtcedef.IntegerDataEncoding(size_in_bits=2, encoding="unsigned")),
-         {},
-         xtcedef.PacketData(0b0011.to_bytes(length=1, byteorder='big')),
+         xtcedef.Packet(0b0011.to_bytes(length=1, byteorder='big')),
          0, False),
         (xtcedef.BooleanParameterType(
             'TEST_BOOL',
             xtcedef.IntegerDataEncoding(size_in_bits=2, encoding="unsigned")),
-         {},
-         xtcedef.PacketData(0b00001111.to_bytes(length=1, byteorder='big'), pos=4),
+         xtcedef.Packet(0b00001111.to_bytes(length=1, byteorder='big'), pos=4),
          3, True),
         (xtcedef.BooleanParameterType(
             'TEST_BOOL',
             xtcedef.FloatDataEncoding(size_in_bits=16)),
-         {},
-         xtcedef.PacketData(0b01010001010000001111111110000000.to_bytes(length=4, byteorder='big')),
+         xtcedef.Packet(0b01010001010000001111111110000000.to_bytes(length=4, byteorder='big')),
          42.0, True),
         (xtcedef.BooleanParameterType(
             'TEST_BOOL',
             xtcedef.FloatDataEncoding(size_in_bits=16)),
-         {},
-         xtcedef.PacketData(0b00000000101000101000000111111111.to_bytes(length=4, byteorder='big'), pos=7),
+         xtcedef.Packet(0b00000000101000101000000111111111.to_bytes(length=4, byteorder='big'), pos=7),
          42.0, True),
     ]
 )
-def test_boolean_parameter_parsing(parameter_type, parsed_data, packet_data, expected_raw, expected_derived):
+def test_boolean_parameter_parsing(parameter_type, packet, expected_raw, expected_derived):
     """Test parsing boolean parameters"""
-    raw, derived = parameter_type.parse_value(packet_data, parsed_data)
+    raw, derived = parameter_type.parse_value(packet)
     assert raw == expected_raw
     assert derived == expected_derived
 
@@ -1939,14 +1907,13 @@ def test_absolute_time_parameter_type(xml_string, expectation):
 
 
 @pytest.mark.parametrize(
-    ('parameter_type', 'parsed_data', 'packet_data', 'expected_raw', 'expected_derived'),
+    ('parameter_type', 'packet', 'expected_raw', 'expected_derived'),
     [
         (xtcedef.AbsoluteTimeParameterType(name='TEST_PARAM_Type', unit='seconds',
                                            encoding=xtcedef.IntegerDataEncoding(size_in_bits=32, encoding="unsigned"),
                                            epoch="TAI", offset_from="MilliSeconds"),
-         {},
          # Exactly 64 bits so neatly goes into a bytes object without padding
-         xtcedef.PacketData(0b0011010000110010010100110000000001001011000000000100100100000000.to_bytes(length=8, byteorder='big')),
+         xtcedef.Packet(0b0011010000110010010100110000000001001011000000000100100100000000.to_bytes(length=8, byteorder='big')),
          875713280, 875713280),
         (xtcedef.AbsoluteTimeParameterType(
              name='TEST_PARAM_Type', unit='s',
@@ -1958,9 +1925,8 @@ def test_absolute_time_parameter_type(xml_string, expectation):
                          xtcedef.PolynomialCoefficient(1E-6, 1)
                      ])),
              epoch="2009-10-10T12:00:00-05:00", offset_from="MilliSeconds"),
-         {},
          # Exactly 64 bits so neatly goes into a bytes object without padding
-         xtcedef.PacketData(0b0011010000110010010100110000000001001011000000000100100100000000.to_bytes(length=8, byteorder='big')),
+         xtcedef.Packet(0b0011010000110010010100110000000001001011000000000100100100000000.to_bytes(length=8, byteorder='big')),
          875713280, 875.7132799999999),
         (xtcedef.AbsoluteTimeParameterType(
              name='TEST_PARAM_Type', unit='s',
@@ -1971,15 +1937,14 @@ def test_absolute_time_parameter_type(xml_string, expectation):
                          xtcedef.PolynomialCoefficient(147.884, 0),
                          xtcedef.PolynomialCoefficient(1, 1)
                      ]))),
-         {},
          # 65 bits, so we need a 9th byte with 7 bits of padding to hold it,
          # which means we need to be starting at pos=7
-         xtcedef.PacketData(0b01000000010010010000111111011011001001011000000000100100100000000.to_bytes(length=9, byteorder='big'), pos=7),
+         xtcedef.Packet(0b01000000010010010000111111011011001001011000000000100100100000000.to_bytes(length=9, byteorder='big'), pos=7),
          3.1415927, 151.02559269999998),
     ]
 )
-def test_absolute_time_parameter_parsing(parameter_type, parsed_data, packet_data, expected_raw, expected_derived):
-    raw, derived = parameter_type.parse_value(packet_data, parsed_data)
+def test_absolute_time_parameter_parsing(parameter_type, packet, expected_raw, expected_derived):
+    raw, derived = parameter_type.parse_value(packet)
     assert round(raw, 5) == round(expected_raw, 5)
     # NOTE: derived values are rounded for comparison due to imprecise storage of floats
     assert round(derived, 5) == round(expected_derived, 5)


### PR DESCRIPTION
This combines the `PacketData` and `Packet` classes together. A `Packet` now contains all of the raw bytes, and can be "parsed" as it goes keeping track of the reading. This enables us to avoid having to pass in `parsed_data` to the parsing methods and just pass in the `Packet` container that already has that information. It would be good to look at the definition of that class and let me know what you think it should/should not contain as public/private methods (maybe we don't want to make the reads public?).

This simplifies some of the tests so we don't always have to pass in `parsed_data={}` now.

This seems to speed up the test suite pretty significantly too. I went from 15s to 7.5 s locally.

## Checklist
- [ ] Changes are fully implemented without dangling issues or TODO items
- [ ] Deprecated/superseded code is removed or marked with deprecation warning
- [ ] Current dependencies have been properly specified and old dependencies removed
- [ ] New code/functionality has accompanying tests and any old tests have been updated to match any new assumptions
- [ ] The changelog.md has been updated
