### PR TITLE
Support MIL-1750A Float Encoding

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -4,7 +4,7 @@ jobs:
   python-version-matrix:
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
     uses: ./.github/workflows/test-python-version.yml
     with:
       python-version: ${{ matrix.python-version }}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,13 +9,6 @@ services:
     build:
       target: style
 
-  3.8-tests:
-    image: space-packets-3.8-test:latest
-    build:
-      target: test
-      args:
-        - BASE_IMAGE_PYTHON_VERSION=3.8
-
   3.9-tests:
     image: space-packets-3.9-test:latest
     build:

--- a/docs/source/changelog.md
+++ b/docs/source/changelog.md
@@ -16,6 +16,7 @@ Release notes for the `space_packet_parser` library
   ``f"{int.from_bytes(data, byteorder='big'):0{len(data)*8}b}"``
 - Fix EnumeratedParameterType to handle duplicate labels
 - Add error reporting for unsupported and invalid parameter types
+- Add support for MIL-1750A floats (32-bit only)
 
 ### v4.2.0 (released)
 - Parse short and long descriptions of parameters

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ keywords = [
 ]
 
 [tool.poetry.dependencies]
-python = ">=3.8"
+python = ">=3.9"
 lxml = ">=4.8.0"
 
 [tool.poetry.group.dev.dependencies]
@@ -50,6 +50,7 @@ myst-parser = "*"
 sphinx-autoapi = "*"
 sphinx-rtd-theme = "*"
 coverage = "*"
+numpy = "*"
 
 [tool.poetry.group.examples]
 optional = true


### PR DESCRIPTION
# Support MIL-1750A Float Encoding

Bump python requirement to 3.9 and remove 3.8 tests and github workflow
Add support for MIL-1750A float parsing
Add test cases pulled from MIL-1750A standard document

## Checklist
- [x] Changes are fully implemented without dangling issues or TODO items
- [x] Deprecated/superseded code is removed or marked with deprecation warning
- [x] Current dependencies have been properly specified and old dependencies removed
- [x] New code/functionality has accompanying tests and any old tests have been updated to match any new assumptions
- [x] The changelog.md has been updated
