### PR TITLE
MNT: Make packet class be a mapping based on data items

### DIFF
--- a/docs/source/changelog.md
+++ b/docs/source/changelog.md
@@ -16,6 +16,9 @@ Release notes for the `space_packet_parser` library
 - BREAKING: The return type of BinaryDataEncoding is now the raw bytes.
   To get the previous behavior you can convert the data to an integer and then format it as a binary string.
   ``f"{int.from_bytes(data, byteorder='big'):0{len(data)*8}b}"``
+- The ``CCSDSPacket`` class is now a dictionary subclass, enabling direct lookup of items from the Packet itself.
+- A ``RawPacketData`` class has been added that is a subclass of bytes. It keeps track of the current
+  parsing location and enables reading of bit lengths as integers or raw bytes.
 - Fix EnumeratedParameterType to handle duplicate labels
 - Add error reporting for unsupported and invalid parameter types
 - Add support for MIL-1750A floats (32-bit only)

--- a/docs/source/users.md
+++ b/docs/source/users.md
@@ -30,8 +30,8 @@ with packet_file.open("rb") as binary_data:
 
     for packet in packet_generator:
         # Do something with the packet data
-        print(packet.header['PKT_APID'])
-        print(packet.data)
+        print(packet['PKT_APID'])
+        print(packet.user_data)
 ```
 
 Usage with CSV packet definition:
@@ -50,8 +50,8 @@ with packet_file.open("rb") as binary_data:
 
     for packet in packet_generator:
         # Do something with the packet data
-        print(packet.header['PKT_APID'])
-        print(packet.data)
+        print(packet['PKT_APID'])
+        print(packet.user_data)
 ```
 
 ## Examples

--- a/examples/parsing_and_plotting_idex_waveforms_from_socket.py
+++ b/examples/parsing_and_plotting_idex_waveforms_from_socket.py
@@ -116,8 +116,8 @@ if __name__ == "__main__":
         p = next(idex_packet_generator)
         print(p)
         while True:
-            if 'IDX__SCI0TYPE' in p.data:
-                scitype = p.data['IDX__SCI0TYPE'].raw_value
+            if 'IDX__SCI0TYPE' in p:
+                scitype = p['IDX__SCI0TYPE'].raw_value
                 print(scitype)
                 if scitype == 1:  # This packet marks the beginning of an "event"
                     data = {}
@@ -125,23 +125,23 @@ if __name__ == "__main__":
                     # Each time we encounter a new scitype, that represents a new channel so we create a new array.
                     # A single channel of data may be spread between multiple packets, which must be concatenated.
                     p = next(idex_packet_generator)
-                    scitype = p.data['IDX__SCI0TYPE'].raw_value
+                    scitype = p['IDX__SCI0TYPE'].raw_value
                     print(scitype, end=", ")
-                    data[scitype] = p.data['IDX__SCI0RAW'].raw_value
+                    data[scitype] = p['IDX__SCI0RAW'].raw_value
                     while True:
                         # If we run into the end of the file, this will raise StopIteration and break both while loops
                         p_next = next(idex_packet_generator)
-                        next_scitype = p_next.data['IDX__SCI0TYPE'].raw_value
+                        next_scitype = p_next['IDX__SCI0TYPE'].raw_value
                         print(next_scitype, end=", ")
                         if next_scitype == scitype:
                             # If the scitype is the same as the last packet, then concatenate them
-                            data[scitype] += p_next.data['IDX__SCI0RAW'].raw_value
+                            data[scitype] += p_next['IDX__SCI0RAW'].raw_value
                         else:
                             # Otherwise check if we are at the end of the event (next scitype==1)
                             if next_scitype == 1:
                                 break
                             scitype = next_scitype
-                            data[scitype] = p_next.data['IDX__SCI0RAW'].raw_value
+                            data[scitype] = p_next['IDX__SCI0RAW'].raw_value
                     p = p_next
                     # If you have more than one complete event in a file (i.e. scitype 1, 2, 4, 8, 16, 32, 64),
                     # this loop would continue.

--- a/space_packet_parser/parameters.py
+++ b/space_packet_parser/parameters.py
@@ -110,13 +110,13 @@ class ParameterType(comparisons.AttrComparable, metaclass=ABCMeta):
                 return data_encoding.from_data_encoding_xml_element(element, ns)
         return None
 
-    def parse_value(self, packet: parseables.Packet, **kwargs):
+    def parse_value(self, packet: parseables.CCSDSPacket, **kwargs):
         """Using the parameter type definition and associated data encoding, parse a value from a bit stream starting
         at the current cursor position.
 
         Parameters
         ----------
-        packet: Packet
+        packet: CCSDSPacket
             Binary representation of the packet used to get the coming bits and any
             previously parsed data items to infer field lengths.
 
@@ -231,13 +231,13 @@ class EnumeratedParameterType(ParameterType):
             for el in enumeration_list.iterfind('xtce:Enumeration', ns)
         }
 
-    def parse_value(self, packet: parseables.Packet, **kwargs):
+    def parse_value(self, packet: parseables.CCSDSPacket, **kwargs):
         """Using the parameter type definition and associated data encoding, parse a value from a bit stream starting
         at the current cursor position.
 
         Parameters
         ----------
-        packet: Packet
+        packet: CCSDSPacket
             Binary representation of the packet used to get the coming bits and any
             previously parsed data items to infer field lengths.
 
@@ -290,13 +290,13 @@ class BooleanParameterType(ParameterType):
                           f"encoded booleans is not specified in XTCE. e.g. is the string \"0\" truthy?")
         super().__init__(name, encoding, unit)
 
-    def parse_value(self, packet: parseables.Packet, **kwargs):
+    def parse_value(self, packet: parseables.CCSDSPacket, **kwargs):
         """Using the parameter type definition and associated data encoding, parse a value from a bit stream starting
         at the current cursor position.
 
         Parameters
         ----------
-        packet: Packet
+        packet: CCSDSPacket
             Binary representation of the packet used to get the coming bits and any
             previously parsed data items to infer field lengths.
 
@@ -516,15 +516,15 @@ class Parameter(parseables.Parseable):
     short_description: Optional[str] = None
     long_description: Optional[str] = None
 
-    def parse(self, packet: parseables.Packet, **parse_value_kwargs) -> dict:
+    def parse(self, packet: parseables.CCSDSPacket, **parse_value_kwargs) -> None:
         """Parse this parameter from the packet data.
 
-        Create a ``ParsedDataItem`` and add it to the parsed_items dictionary.
+        Create a ``ParsedDataItem`` and add it to the packet dictionary.
         """
         parsed_value, derived_value = self.parameter_type.parse_value(
             packet, **parse_value_kwargs)
 
-        packet.parsed_data[self.name] = parseables.ParsedDataItem(
+        packet[self.name] = parseables.ParsedDataItem(
             name=self.name,
             unit=self.parameter_type.unit,
             raw_value=parsed_value,
@@ -532,4 +532,3 @@ class Parameter(parseables.Parseable):
             short_description=self.short_description,
             long_description=self.long_description
         )
-        return packet.parsed_data

--- a/space_packet_parser/parseables.py
+++ b/space_packet_parser/parseables.py
@@ -33,41 +33,32 @@ class ParsedDataItem:
     long_description: Optional[str] = None
 
 
-@dataclass
-class Packet:
-    """CCSDS Packet
+class RawPacketData(bytes):
+    """A class to represent raw packet data as bytes.
 
-    Can be parsed to populate data items. This ``Packet`` class keeps track
-    of the current parsing position for know where to read from next when
-    parsing data items.
+    This class is a subclass of bytes and is used to represent the raw packet data
+    in a more readable way. It is used to store the raw packet data in the Packet
+    class and used to keep track of the current parsing position.
 
     Parameters
     ----------
     data : bytes
-        The binary data for a single packet.
-    pos : int
-        The bit cursor position in the packet. Default 0.
+        Raw packet data. Full CCSDS packets are always an integer number of bytes.
     """
-    rawdata: bytes
-    pos: Optional[int] = 0
-    parsed_data: Optional[dict] = field(default_factory=lambda: {})
+    def __init__(self, data: bytes, *, pos: int = 0):
+        self.pos = pos
+        self._nbits = len(data) * 8
+        super().__init__()
 
     def __len__(self):
-        """The length of the full packet data object in bits."""
-        return len(self.rawdata) * 8
+        return self._nbits
 
-    @property
-    def header(self):
-        """The header content of the packet."""
-        return dict(list(self.parsed_data.items())[:7])
-
-    @property
-    def data(self):
-        """The user data content of the packet."""
-        return dict(list(self.parsed_data.items())[7:])
+    def __repr__(self):
+        return f"RawPacketData({self}, {len(self)}B, pos={self.pos})"
 
     def read_as_bytes(self, nbits: int) -> bytes:
-        """Read a number of bits from the packet data as bytes.
+        """Read a number of bits from the packet data as bytes. Reads minimum number of complete bytes required to
+        capture `nbits`. Moves `pos` cursor `nbits` forward, even if `nbits` is not an integer number of bytes.
 
         Parameters
         ----------
@@ -83,11 +74,11 @@ class Packet:
             raise ValueError("End of packet reached")
         if self.pos % 8 == 0 and nbits % 8 == 0:
             # If the read is byte-aligned, we can just return the bytes directly
-            data = self.rawdata[self.pos//8:self.pos//8 + nbits // 8]
+            data = self[self.pos//8:self.pos//8 + (nbits+7) // 8]
             self.pos += nbits
             return data
         # We are non-byte aligned, so we need to extract the bits and convert to bytes
-        bytes_as_int = _extract_bits(self.rawdata, self.pos, nbits)
+        bytes_as_int = _extract_bits(self, self.pos, nbits)
         self.pos += nbits
         return int.to_bytes(bytes_as_int, (nbits + 7) // 8, "big")
 
@@ -104,15 +95,49 @@ class Packet:
         : int
             Integer representation of the bits read from the packet
         """
-        int_data = _extract_bits(self.rawdata, self.pos, nbits)
+        int_data = _extract_bits(self, self.pos, nbits)
         self.pos += nbits
         return int_data
 
 
+class CCSDSPacket(dict):
+    """CCSDS Packet
+
+    Container that stores the raw packet data (bytes) as an instance attribute and the parsed
+    data items in a dict interface. A ``CCSDSPacket`` generally begins as an empty dictionary that gets
+    filled as the packet is parsed. The first 7 items in the dictionary make up the
+    packet header (accessed with ``CCSDSPacket.header``), and the rest of the items
+    make up the user data (accessed with ``CCSDSPacket.user_data``). To access the
+    raw bytes of the packet, use the ``CCSDSPacket.raw_data`` attribute.
+
+    Parameters
+    ----------
+    *args : Mapping or Iterable
+        Initial items to store in the packet, passed to the dict() constructor.
+    raw_data : bytes, optional
+        The binary data for a single packet.
+    **kwargs : dict
+        Additional packet items to store, passed to the dict() constructor.
+    """
+    def __init__(self, *args, raw_data: bytes = b"", **kwargs):
+        self.raw_data = RawPacketData(raw_data)
+        super().__init__(*args, **kwargs)
+
+    @property
+    def header(self) -> dict:
+        """The header content of the packet."""
+        return dict(list(self.items())[:7])
+
+    @property
+    def user_data(self) -> dict:
+        """The user data content of the packet."""
+        return dict(list(self.items())[7:])
+
+
 class Parseable(Protocol):
     """Defines an object that can be parsed from packet data."""
-    def parse(self, packet: Packet, **parse_value_kwargs) -> dict:
-        """Parse this entry from the packet data and add the necessary items to the parsed_items dictionary."""
+    def parse(self, packet: CCSDSPacket, **parse_value_kwargs) -> None:
+        """Parse this entry from the packet data and add the necessary items to the packet."""
 
 
 @dataclass
@@ -152,14 +177,13 @@ class SequenceContainer(Parseable):
         self.restriction_criteria = self.restriction_criteria or []
         self.inheritors = self.inheritors or []
 
-    def parse(self, packet: Packet, **parse_value_kwargs) -> dict:
+    def parse(self, packet: CCSDSPacket, **parse_value_kwargs) -> None:
         """Parse the entry list of parameters/containers in the order they are expected in the packet.
 
         This could be recursive if the entry list contains SequenceContainers.
         """
         for entry in self.entry_list:
-            packet.parsed_data = entry.parse(packet=packet, **parse_value_kwargs)
-        return packet.parsed_data
+            entry.parse(packet=packet, **parse_value_kwargs)
 
 
 FlattenedContainer = namedtuple('FlattenedContainer', ['entry_list', 'restrictions'])

--- a/tests/integration/test_bufferedreader_parsing.py
+++ b/tests/integration/test_bufferedreader_parsing.py
@@ -17,7 +17,7 @@ def test_jpss_xtce_packet_parsing(jpss_test_data_dir):
         jpss_packet_generator = jpss_parser.generator(binary_data, show_progress=True)
         n_packets = 0
         for jpss_packet in jpss_packet_generator:
-            assert isinstance(jpss_packet, parseables.Packet)
+            assert isinstance(jpss_packet, parseables.CCSDSPacket)
             assert jpss_packet.header['PKT_APID'].raw_value == 11
             assert jpss_packet.header['VERSION'].raw_value == 0
             n_packets += 1

--- a/tests/integration/test_csv_based_parsing/test_ctim_parsing.py
+++ b/tests/integration/test_csv_based_parsing/test_ctim_parsing.py
@@ -15,5 +15,5 @@ def test_csv_packet_definition_parsing(ctim_test_data_dir):
         packets = list(pkt_gen)
 
     assert(len(packets) == 1499)
-    assert(packets[159].header['PKT_APID'].raw_value == 34)
-    assert(packets[159].data['SHCOARSE'].raw_value == 481168702)
+    assert(packets[159]['PKT_APID'].raw_value == 34)
+    assert(packets[159]['SHCOARSE'].raw_value == 481168702)

--- a/tests/integration/test_xtce_based_parsing/test_inheritance_restrictions.py
+++ b/tests/integration/test_xtce_based_parsing/test_inheritance_restrictions.py
@@ -16,7 +16,7 @@ def test_jpss_xtce_packet_parsing(jpss_test_data_dir):
         jpss_packet_generator = jpss_parser.generator(binary_data)
         for _ in range(3):  # Iterate through 3 packets and check that the parsed APID remains the same
             jpss_packet = next(jpss_packet_generator)
-            assert isinstance(jpss_packet, parseables.Packet)
+            assert isinstance(jpss_packet, parseables.CCSDSPacket)
             assert jpss_packet.header['PKT_APID'].raw_value == 11
             assert jpss_packet.header['VERSION'].raw_value == 0
         jpss_packet_generator.close()

--- a/tests/integration/test_xtce_based_parsing/test_jpss_parsing.py
+++ b/tests/integration/test_xtce_based_parsing/test_jpss_parsing.py
@@ -18,10 +18,10 @@ def test_jpss_xtce_packet_parsing(jpss_test_data_dir):
 
         n_packets = 0
         for jpss_packet in jpss_packet_generator:
-            assert isinstance(jpss_packet, parseables.Packet)
+            assert isinstance(jpss_packet, parseables.CCSDSPacket)
             assert jpss_packet.header['PKT_APID'].raw_value == 11
             assert jpss_packet.header['VERSION'].raw_value == 0
-            assert jpss_packet.data['USEC'].short_description == "Secondary Header Fine Time (microsecond)"
-            assert jpss_packet.data['USEC'].long_description == "CCSDS Packet 2nd Header Fine Time in microseconds."
+            assert jpss_packet['USEC'].short_description == "Secondary Header Fine Time (microsecond)"
+            assert jpss_packet['USEC'].long_description == "CCSDS Packet 2nd Header Fine Time in microseconds."
             n_packets += 1
         assert n_packets == 7200

--- a/tests/integration/test_xtce_based_parsing/test_suda_parsing.py
+++ b/tests/integration/test_xtce_based_parsing/test_suda_parsing.py
@@ -55,7 +55,7 @@ def test_suda_xtce_packet_parsing(suda_test_data_dir):
                                                       skip_header_bits=32,
                                                       show_progress=True)
         for suda_packet in suda_packet_generator:
-            assert isinstance(suda_packet, parseables.Packet)
+            assert isinstance(suda_packet, parseables.CCSDSPacket)
             assert suda_packet.header['PKT_APID'].raw_value == 1425, "APID is not as expected."
             assert suda_packet.header['VERSION'].raw_value == 0, "CCSDS header VERSION incorrect."
 
@@ -66,31 +66,31 @@ def test_suda_xtce_packet_parsing(suda_test_data_dir):
         try:
             p = next(suda_packet_generator)
             while True:
-                if 'IDX__SCIFETCHTYPE' in p.data:
-                    scitype = p.data['IDX__SCIFETCHTYPE'].raw_value
+                if 'IDX__SCIFETCHTYPE' in p:
+                    scitype = p['IDX__SCIFETCHTYPE'].raw_value
                     print(scitype)
                     if scitype == 1:  # beginning of an event
                         data = {}
                         event_header = p
                         # Each time we encounter a new scitype, we create a new array.
                         p = next(suda_packet_generator)
-                        scitype = p.data['IDX__SCIFETCHTYPE'].raw_value
+                        scitype = p['IDX__SCIFETCHTYPE'].raw_value
                         print(scitype, end=", ")
-                        data[scitype] = p.data['IDX__SCIFETCHRAW'].raw_value
+                        data[scitype] = p['IDX__SCIFETCHRAW'].raw_value
                         while True:
                             # If we run into the end of the file, this will raise StopIteration
                             p_next = next(suda_packet_generator)
-                            next_scitype = p_next.data['IDX__SCIFETCHTYPE'].raw_value
+                            next_scitype = p_next['IDX__SCIFETCHTYPE'].raw_value
                             print(next_scitype, end=", ")
                             if next_scitype == scitype:
                                 # If the scitype is the same as the last packet, then concatenate them
-                                data[scitype] += p_next.data['IDX__SCIFETCHRAW'].raw_value
+                                data[scitype] += p_next['IDX__SCIFETCHRAW'].raw_value
                             else:
                                 # Otherwise check if we are at the end of the event (next scitype==1)
                                 if next_scitype == 1:
                                     break
                                 scitype = next_scitype
-                                data[scitype] = p_next.data['IDX__SCIFETCHRAW'].raw_value
+                                data[scitype] = p_next['IDX__SCIFETCHRAW'].raw_value
                         p = p_next
                         # If you have more than one event in a file (i.e. scitype 1, 2, 4, 8, 16, 32, 64),
                         # this loop would continue.

--- a/tests/unit/test_csvdef.py
+++ b/tests/unit/test_csvdef.py
@@ -58,4 +58,4 @@ def test_csv_packet_definition(ctim_test_data_dir):
         parser_inst = parser.PacketParser(csv_pkt_def)
         pkt_gen = parser_inst.generator(pkt_file, show_progress=True)
         packet = next(pkt_gen)
-    assert isinstance(packet, parseables.Packet)
+    assert isinstance(packet, parseables.CCSDSPacket)

--- a/tests/unit/test_parseables.py
+++ b/tests/unit/test_parseables.py
@@ -1,0 +1,49 @@
+import pytest
+
+from space_packet_parser import parseables
+
+
+@pytest.mark.parametrize(("raw_value", "start", "nbits", "expected"),
+                         [(0b11000000, 0, 2, 0b11),
+                          (0b11000000, 1, 2, 0b10),
+                          (0b11000000, 2, 2, 0b00),
+                          (0b11000011, 6, 2, 0b11),
+                          (0b11000011, 7, 1, 0b1),
+                          # Go across byte boundaries
+                          (0b1100001111000011, 6, 4, 0b1111),
+                          (0b1100001111000011, 6, 6, 0b111100),
+                          (0b1100001111000011, 8, 6, 0b110000),
+                          (0b1100001111000011, 8, 8, 0b11000011),
+                          # Multiple bytes
+                          (0b110000111100001100000000, 8, 10, 0b1100001100),
+                          (0b110000111100001100000000, 0, 24, 0b110000111100001100000000)])
+def test_raw_packet_data(raw_value, start, nbits, expected):
+    raw_bytes = raw_value.to_bytes((raw_value.bit_length() + 7) // 8, "big")
+    raw_packet = parseables.RawPacketData(raw_bytes)
+    raw_packet.pos = start
+    assert raw_packet.read_as_int(nbits) == expected
+    assert raw_packet.pos == start + nbits
+    # Reset the position and read again but as raw bytes this time
+    raw_packet.pos = start
+    # the value 0 has a bit_length of 0, so we need to ensure we have at least 1 byte
+    assert raw_packet.read_as_bytes(nbits) == expected.to_bytes((max(expected.bit_length(), 1) + 7) // 8, "big")
+    assert raw_packet.pos == start + nbits
+
+
+def test_ccsds_packet():
+    packet = parseables.CCSDSPacket(raw_data=b"123")
+    assert packet.raw_data == b"123"
+    # There are no items yet, so it should be an empty dictionary
+    assert packet == {}
+    assert packet.header == {}
+    assert packet.user_data == {}
+    # Now populated some packet items
+    packet.update({x: x for x in range(10)})
+    assert packet[5] == 5
+    assert packet == {x: x for x in range(10)}
+    # The header is the first 7 items
+    assert packet.header == {x: x for x in range(7)}
+    assert packet.user_data == {x: x for x in range(7, 10)}
+
+    with pytest.raises(KeyError):
+        packet[10]

--- a/tests/unit/test_xtcedef.py
+++ b/tests/unit/test_xtcedef.py
@@ -1131,7 +1131,7 @@ def test_string_parameter_type(xml_string: str, expectation):
 
 
 @pytest.mark.parametrize(
-    ('parameter_type', 'packet', 'expected'),
+    ('parameter_type', 'raw_data', 'current_pos', 'expected'),
     [
         # Fixed length test
         (parameters.StringParameterType(
@@ -1139,7 +1139,8 @@ def test_string_parameter_type(xml_string: str, expectation):
             encodings.StringDataEncoding(fixed_length=3,  # Giving length in bytes
                                        length_linear_adjuster=lambda x: 8*x)),
          # This still 123X456
-         parseables.Packet(b'123X456'),
+         b'123X456',
+         0,
          '123'),
         # Dynamic reference length
         (parameters.StringParameterType(
@@ -1147,8 +1148,8 @@ def test_string_parameter_type(xml_string: str, expectation):
             encodings.StringDataEncoding(dynamic_length_reference='STR_LEN',
                                        use_calibrated_value=False,
                                        length_linear_adjuster=lambda x: 8*x)),
-         parseables.Packet(b'BAD WOLF', parsed_data={
-             'STR_LEN': parseables.ParsedDataItem('STR_LEN', 8, None)}),
+         b'BAD WOLF',
+         0,
          'BAD WOLF'),
         # Discrete lookup test
         (parameters.StringParameterType(
@@ -1159,8 +1160,8 @@ def test_string_parameter_type(xml_string: str, expectation):
                     comparisons.Comparison(99, 'P2', '==', use_calibrated_value=False)
                 ], lookup_value=8)
             ], length_linear_adjuster=lambda x: 8*x)),
-         parseables.Packet(b'BAD WOLF', parsed_data={
-             'P1': parseables.ParsedDataItem('P1', 7, None, 7.55), 'P2': parseables.ParsedDataItem('P2', 99, None, 100)},),
+         b'BAD WOLF',
+         0,
          'BAD WOLF'),
         # Termination character tests
         (parameters.StringParameterType(
@@ -1168,14 +1169,16 @@ def test_string_parameter_type(xml_string: str, expectation):
             encodings.StringDataEncoding(encoding='UTF-8',
                                        termination_character='58')),
          # 123X456 + extra characters, termination character is X
-         parseables.Packet(b'123X456000000000000000000000000000000000000000000000'),
+         b'123X456000000000000000000000000000000000000000000000',
+         0,
          '123'),
         (parameters.StringParameterType(
             'TEST_STRING',
             encodings.StringDataEncoding(encoding='UTF-8',
                                        termination_character='58')),
          # 56bits + 123X456 + extra characters, termination character is X
-         parseables.Packet(b'9090909123X456000000000000000000000000000000000000000000000', pos=56),
+         b'9090909123X456000000000000000000000000000000000000000000000',
+         56,
          '123'),
         (parameters.StringParameterType(
             'TEST_STRING',
@@ -1183,32 +1186,37 @@ def test_string_parameter_type(xml_string: str, expectation):
                                        termination_character='58')),
          # 53bits + 123X456 + extra characters, termination character is X
          # This is the same string as above but bit-shifted left by 3 bits
-         parseables.Packet(b'\x03K;s{\x93)\x89\x91\x9a\xc1\xa1\xa9\xb3K;s{\x93(', pos=53),
+         b'\x03K;s{\x93)\x89\x91\x9a\xc1\xa1\xa9\xb3K;s{\x93(',
+         53,
          '123'),
         (parameters.StringParameterType(
             "TEST_STRING",
             encodings.StringDataEncoding(encoding="UTF-8",
                                        termination_character='00')),
-         parseables.Packet("false_is_truthy".encode("UTF-8") + b'\x00ABCD'),
+         "false_is_truthy".encode("UTF-8") + b'\x00ABCD',
+         0,
          'false_is_truthy'),
         (parameters.StringParameterType(
             "TEST_STRING",
             encodings.StringDataEncoding(encoding="UTF-16BE",
                                        termination_character='0021')),
-         parseables.Packet("false_is_truthy".encode("UTF-16BE") + b'\x00\x21ignoreme'),
+         "false_is_truthy".encode("UTF-16BE") + b'\x00\x21ignoreme',
+         0,
          'false_is_truthy'),
         (parameters.StringParameterType(
             'TEST_STRING',
             encodings.StringDataEncoding(encoding='UTF-16LE',
                                        termination_character='5800')),
          # 123X456, termination character is X
-         parseables.Packet('123X456'.encode('UTF-16LE')),
+         '123X456'.encode('UTF-16LE'),
+         0,
          '123'),
         (parameters.StringParameterType(
             'TEST_STRING',
             encodings.StringDataEncoding(encoding='UTF-16BE',
                                        termination_character='0058')),
-         parseables.Packet('123X456'.encode('UTF-16BE')),
+         '123X456'.encode('UTF-16BE'),
+         0,
          '123'),
         # Leading length test
         (parameters.StringParameterType(
@@ -1216,12 +1224,19 @@ def test_string_parameter_type(xml_string: str, expectation):
             encodings.StringDataEncoding(leading_length_size=5)),
          # This is still 123X456 but with 11000 prepended (a 5-bit representation of the number 24)
          # This represents a string length (in bits) of 24 bits.
-         parseables.Packet(0b1100000110001001100100011001101011000001101000011010100110110000.to_bytes(8, byteorder="big")),
+         0b1100000110001001100100011001101011000001101000011010100110110000.to_bytes(8, byteorder="big"),
+         0,
          '123'),
     ]
 )
-def test_string_parameter_parsing(parameter_type, packet, expected):
+def test_string_parameter_parsing(parameter_type, raw_data, current_pos, expected):
     """Test parsing a string parameter"""
+    # pre parsed data to reference for lookups
+    packet = parseables.CCSDSPacket(raw_data=raw_data, **{'P1': parseables.ParsedDataItem('P1', 7, None, 7.55),
+                   'P2': parseables.ParsedDataItem('P2', 99, None, 100),
+                   'STR_LEN': parseables.ParsedDataItem('STR_LEN', 8, None)})
+    # Artificially set the current position of the packet data read so far
+    packet.raw_data.pos = current_pos
     raw, _ = parameter_type.parse_value(packet)
     assert raw == expected
 
@@ -1306,27 +1321,31 @@ def test_integer_parameter_type(xml_string: str, expectation):
 
 
 @pytest.mark.parametrize(
-    ('parameter_type', 'packet', 'expected'),
+    ('parameter_type', 'raw_data', 'current_pos', 'expected'),
     [
         # 16-bit unsigned starting at byte boundary
         (parameters.IntegerParameterType('TEST_INT', encodings.IntegerDataEncoding(16, 'unsigned')),
-         parseables.Packet(0b1000000000000000.to_bytes(length=2, byteorder='big')),
+         0b1000000000000000.to_bytes(length=2, byteorder='big'),
+         0,
          32768),
         # 16-bit unsigned little endian at byte boundary
         (parameters.IntegerParameterType(
             'TEST_INT',
             encodings.IntegerDataEncoding(16, 'unsigned', byte_order="leastSignificantByteFirst")),
-         parseables.Packet(0b1000000000000000.to_bytes(length=2, byteorder='big')),
+         0b1000000000000000.to_bytes(length=2, byteorder='big'),
+         0,
          128),
         # 16-bit signed starting at byte boundary
         (parameters.IntegerParameterType('TEST_INT', encodings.IntegerDataEncoding(16, 'signed')),
-         parseables.Packet(0b1111111111010110.to_bytes(length=2, byteorder='big')),
+         0b1111111111010110.to_bytes(length=2, byteorder='big'),
+         0,
          -42),
         # 16-bit signed little endian starting at byte boundary
         (parameters.IntegerParameterType(
             'TEST_INT',
             encodings.IntegerDataEncoding(16, 'signed', byte_order="leastSignificantByteFirst")),
-         parseables.Packet(0b1101011011111111.to_bytes(length=2, byteorder='big')),
+         0b1101011011111111.to_bytes(length=2, byteorder='big'),
+         0,
          -42),
         # 16-bit signed integer starting at a byte boundary,
         # calibrated by a polynomial y = (x*2 + 5); x = -42; y = -84 + 5 = -79
@@ -1342,39 +1361,44 @@ def test_integer_parameter_type(xml_string: str, expectation):
                         calibrators.PolynomialCalibrator([calibrators.PolynomialCoefficient(5, 0),
                                                       calibrators.PolynomialCoefficient(2, 1)]))
                 ])),
-         parseables.Packet(0b1111111111010110.to_bytes(length=2, byteorder='big'),
-                            parsed_data={'PKT_APID': parseables.ParsedDataItem('PKT_APID', 1101)},),
+         0b1111111111010110.to_bytes(length=2, byteorder='big'),
+         0,
          -79),
         # 12-bit unsigned integer starting at bit 4 of the first byte
         (parameters.IntegerParameterType('TEST_INT', encodings.IntegerDataEncoding(12, 'unsigned')),
          # 11111000 00000000
          #     |--uint:12--|
-         parseables.Packet(0b1111100000000000.to_bytes(length=2, byteorder='big'), pos=4),
+         0b1111100000000000.to_bytes(length=2, byteorder='big'),
+         4,
          2048),
         # 13-bit unsigned integer starting on bit 2 of the second byte
         (parameters.IntegerParameterType('TEST_INT', encodings.IntegerDataEncoding(13, 'unsigned')),
          # 10101010 11100000 00000001
          #            |--uint:13---|
-         parseables.Packet(0b101010101110000000000001.to_bytes(length=3, byteorder='big'), pos=10),
+         0b101010101110000000000001.to_bytes(length=3, byteorder='big'),
+         10,
          4096),
         # 16-bit unsigned integer starting on bit 2 of the first byte
         (parameters.IntegerParameterType('TEST_INT', encodings.IntegerDataEncoding(16, 'unsigned')),
          # 10101010 11100000 00000001
          #   |----uint:16-----|
-         parseables.Packet(0b101010101110000000000001.to_bytes(length=3, byteorder='big'), pos=2),
+         0b101010101110000000000001.to_bytes(length=3, byteorder='big'),
+         2,
          43904),
         # 12-bit signed integer starting on bit 4 of the first byte
         (parameters.IntegerParameterType('TEST_INT', encodings.IntegerDataEncoding(12, 'signed')),
          # 11111000 00000000
          #     |---int:12--|
-         parseables.Packet(0b1111100000000000.to_bytes(length=2, byteorder='big'), pos=4),
+         0b1111100000000000.to_bytes(length=2, byteorder='big'),
+         4,
          -2048),
         # 12-bit signed integer starting on bit 6 of the first byte
         (parameters.IntegerParameterType('TEST_INT', encodings.IntegerDataEncoding(12, 'signed')),
          # 12-bit signed integer starting on bit 4 of the first byte
          #  11111110 00000000 00111111 10101010
          #        |---int:12---|
-         parseables.Packet(0b11111110000000000011111110101010.to_bytes(length=4, byteorder='big'), pos=6),
+         0b11111110000000000011111110101010.to_bytes(length=4, byteorder='big'),
+         6,
          -2048),
         # 12-bit signed little endian integer starting on bit 6 of the first byte
         (parameters.IntegerParameterType(
@@ -1383,18 +1407,23 @@ def test_integer_parameter_type(xml_string: str, expectation):
          # 12-bit signed little endian integer starting on bit 4 of the first byte. The LSB of the integer comes first
          #  11111100 00000010 00111111 10101010
          #        |---int:12---|
-         parseables.Packet(0b11111100000000100011111110101010.to_bytes(length=4, byteorder='big'), pos=6),
+         0b11111100000000100011111110101010.to_bytes(length=4, byteorder='big'),
+         6,
          -2048),
         (parameters.IntegerParameterType('TEST_INT', encodings.IntegerDataEncoding(3, 'twosComplement')),
          # 3-bit signed integer starting at bit 7 of the first byte
          #  00000001      11000000       00000000
          #         |-int:3-|
-         parseables.Packet(0b000000011100000000000000.to_bytes(length=3, byteorder='big'), pos=7),
+         0b000000011100000000000000.to_bytes(length=3, byteorder='big'),
+         7,
          -1),
     ]
 )
-def test_integer_parameter_parsing(parameter_type, packet, expected):
+def test_integer_parameter_parsing(parameter_type, raw_data, current_pos, expected):
     """Testing parsing an integer parameters"""
+    # pre parsed data to reference for lookups
+    packet = parseables.CCSDSPacket(raw_data=raw_data, PKT_APID=parseables.ParsedDataItem('PKT_APID', 1101))
+    packet.raw_data.pos = current_pos
     raw, derived = parameter_type.parse_value(packet)
     if derived:
         assert derived == expected
@@ -1492,21 +1521,21 @@ def test_float_parameter_type(xml_string: str, expectation):
 
 
 @pytest.mark.parametrize(
-    ('parameter_type', 'packet', 'expected'),
+    ('parameter_type', 'raw_data', 'expected'),
     [
         # Test big endion 32-bit IEEE float
         (parameters.FloatParameterType('TEST_FLOAT', encodings.FloatDataEncoding(32)),
-         parseables.Packet(0b01000000010010010000111111010000.to_bytes(length=4, byteorder='big')),
+         0b01000000010010010000111111010000.to_bytes(length=4, byteorder='big'),
          3.14159),
         # Test little endian 32-bit IEEE float
         (parameters.FloatParameterType(
             'TEST_FLOAT',
             encodings.FloatDataEncoding(32, byte_order='leastSignificantByteFirst')),
-         parseables.Packet(0b01000000010010010000111111010000.to_bytes(length=4, byteorder='little')),
+         0b01000000010010010000111111010000.to_bytes(length=4, byteorder='little'),
          3.14159),
         # Test big endian 64-bit float
         (parameters.FloatParameterType('TEST_FLOAT', encodings.FloatDataEncoding(64)),
-         parseables.Packet(b'\x3F\xF9\xE3\x77\x9B\x97\xF4\xA8'),  # 64-bit IEEE 754 value of Phi
+         b'\x3F\xF9\xE3\x77\x9B\x97\xF4\xA8',  # 64-bit IEEE 754 value of Phi
          1.6180339),
         # Test float parameter type encoded as big endian 16-bit integer with contextual polynomial calibrator
         (parameters.FloatParameterType(
@@ -1521,76 +1550,77 @@ def test_float_parameter_type(xml_string: str, expectation):
                         calibrators.PolynomialCalibrator([calibrators.PolynomialCoefficient(5.6, 0),
                                                       calibrators.PolynomialCoefficient(2.1, 1)]))
                 ])),
-         parseables.Packet(0b1111111111010110.to_bytes(length=2, byteorder='big'),
-                            parsed_data={'PKT_APID': parseables.ParsedDataItem('PKT_APID', 1101)}),
+         0b1111111111010110.to_bytes(length=2, byteorder='big'),
          -82.600000),
         # Test MIL 1750A encoded floats.
         # Test values taken from: https://www.xgc-tek.com/manuals/mil-std-1750a/c191.html#AEN324
         (parameters.FloatParameterType(
             'MIL_1750A_FLOAT',
             encodings.FloatDataEncoding(32, encoding="MIL-1750A")),
-         parseables.Packet(b'\x7f\xff\xff\x7f'),
+         b'\x7f\xff\xff\x7f',
          0.9999998 * (2 ** 127)),
         (parameters.FloatParameterType(
             'MIL_1750A_FLOAT',
             encodings.FloatDataEncoding(32, encoding="MIL-1750A")),
-         parseables.Packet(b'\x40\x00\x00\x7f'),
+         b'\x40\x00\x00\x7f',
          0.5 * (2 ** 127)),
         (parameters.FloatParameterType(
             'MIL_1750A_FLOAT',
             encodings.FloatDataEncoding(32, encoding="MIL-1750A")),
-         parseables.Packet(b'\x50\x00\x00\x04'),
+         b'\x50\x00\x00\x04',
          0.625 * (2 ** 4)),
         (parameters.FloatParameterType(
             'MIL_1750A_FLOAT',
             encodings.FloatDataEncoding(32, encoding="MIL-1750A")),
-         parseables.Packet(b'\x40\x00\x00\x01'),
+         b'\x40\x00\x00\x01',
          0.5 * (2 ** 1)),
         (parameters.FloatParameterType(
             'MIL_1750A_FLOAT',
             encodings.FloatDataEncoding(32, encoding="MIL-1750A")),
-         parseables.Packet(b'\x40\x00\x00\x00'),
+         b'\x40\x00\x00\x00',
          0.5 * (2 ** 0)),
         (parameters.FloatParameterType(
             'MIL_1750A_FLOAT',
             encodings.FloatDataEncoding(32, encoding="MIL-1750A")),
-         parseables.Packet(b'\x40\x00\x00\xff'),
+         b'\x40\x00\x00\xff',
          0.5 * (2 ** -1)),
         (parameters.FloatParameterType(
             'MIL_1750A_FLOAT',
             encodings.FloatDataEncoding(32, encoding="MIL-1750A")),
-         parseables.Packet(b'\x40\x00\x00\x80'),
+         b'\x40\x00\x00\x80',
          0.5 * (2 ** -128)),
         (parameters.FloatParameterType(
             'MIL_1750A_FLOAT',
             encodings.FloatDataEncoding(32, encoding="MIL-1750A")),
-         parseables.Packet(b'\x00\x00\x00\x00'),
+         b'\x00\x00\x00\x00',
          0.0 * (2 ** 0)),
         (parameters.FloatParameterType(
             'MIL_1750A_FLOAT',
             encodings.FloatDataEncoding(32, encoding="MIL-1750A")),
-         parseables.Packet(b'\x80\x00\x00\x00'),
+         b'\x80\x00\x00\x00',
          -1.0 * (2 ** 0)),
         (parameters.FloatParameterType(
             'MIL_1750A_FLOAT',
             encodings.FloatDataEncoding(32, encoding="MIL-1750A")),
-         parseables.Packet(b'\xBF\xFF\xFF\x80'),
+         b'\xBF\xFF\xFF\x80',
          -0.5000001 * (2 ** -128)),
         (parameters.FloatParameterType(
             'MIL_1750A_FLOAT',
             encodings.FloatDataEncoding(32, encoding="MIL-1750A")),
-         parseables.Packet(b'\x9F\xFF\xFF\x04'),
+         b'\x9F\xFF\xFF\x04',
          -0.7500001 * (2 ** 4)),
         # Little endian version of previous test
         (parameters.FloatParameterType(
             'MIL_1750A_FLOAT',
             encodings.FloatDataEncoding(32, encoding="MIL-1750A", byte_order="leastSignificantByteFirst")),
-         parseables.Packet(b'\x04\xFF\xFF\x9F'),
+         b'\x04\xFF\xFF\x9F',
          -0.7500001 * (2 ** 4)),
     ]
 )
-def test_float_parameter_parsing(parameter_type, packet, expected):
+def test_float_parameter_parsing(parameter_type, raw_data, expected):
     """Test parsing float parameters"""
+    # pre parsed data to reference for lookups
+    packet = parseables.CCSDSPacket(raw_data=raw_data, **{'PKT_APID': parseables.ParsedDataItem('PKT_APID', 1101)})
     raw, derived = parameter_type.parse_value(packet)
     # NOTE: These results are compared with a relative tolerance due to the imprecise storage of floats
     if derived:
@@ -1634,22 +1664,23 @@ def test_enumerated_parameter_type(xml_string: str, expectation):
 
 
 @pytest.mark.parametrize(
-    ('parameter_type', 'packet', 'expected'),
+    ('parameter_type', 'raw_data', 'expected'),
     [
         (parameters.EnumeratedParameterType(
             'TEST_ENUM',
             encodings.IntegerDataEncoding(16, 'unsigned'), {32768: 'NOMINAL'}),
-         parseables.Packet(0b1000000000000000.to_bytes(length=2, byteorder='big')),
+         0b1000000000000000.to_bytes(length=2, byteorder='big'),
          'NOMINAL'),
         (parameters.EnumeratedParameterType(
             'TEST_FLOAT',
             encodings.IntegerDataEncoding(16, 'signed'),  {-42: 'VAL_LOW'}),
-         parseables.Packet(0b1111111111010110.to_bytes(length=2, byteorder='big')),
+         0b1111111111010110.to_bytes(length=2, byteorder='big'),
          'VAL_LOW'),
     ]
 )
-def test_enumerated_parameter_parsing(parameter_type, packet, expected):
+def test_enumerated_parameter_parsing(parameter_type, raw_data, expected):
     """"Test parsing enumerated parameters"""
+    packet = parseables.CCSDSPacket(raw_data=raw_data)
     raw, derived = parameter_type.parse_value(packet)
     if derived:
         assert derived == expected
@@ -1734,13 +1765,13 @@ def test_binary_parameter_type(xml_string: str, expectation):
 
 
 @pytest.mark.parametrize(
-    ('parameter_type', 'packet', 'expected'),
+    ('parameter_type', 'raw_data', 'expected'),
     [
         # fixed size
         (parameters.BinaryParameterType(
             'TEST_BIN',
             encodings.BinaryDataEncoding(fixed_size_in_bits=16)),
-         parseables.Packet(0b0011010000110010010100110000000001001011000000000100100100000000.to_bytes(length=8, byteorder='big')),
+         0b0011010000110010010100110000000001001011000000000100100100000000.to_bytes(length=8, byteorder='big'),
          b'42'),
         # discrete lookup list size
         (parameters.BinaryParameterType(
@@ -1751,21 +1782,23 @@ def test_binary_parameter_type(xml_string: str, expectation):
                                        operator='==', use_calibrated_value=True)
                 ], lookup_value=2)
             ], linear_adjuster=lambda x: 8*x)),
-         parseables.Packet(0b0011010000110010010100110000000001001011000000000100100100000000.to_bytes(length=8, byteorder='big'),
-                            parsed_data={'P1': parseables.ParsedDataItem('P1', 1, None, 7.4)}),
+         0b0011010000110010010100110000000001001011000000000100100100000000.to_bytes(length=8, byteorder='big'),
          b'42'),
         # dynamic size reference to other parameter
         (parameters.BinaryParameterType(
             'TEST_BIN',
             encodings.BinaryDataEncoding(size_reference_parameter='BIN_LEN',
                                        use_calibrated_value=False, linear_adjuster=lambda x: 8*x)),
-         parseables.Packet(0b0011010000110010010100110000000001001011000000000100100100000000.to_bytes(length=8, byteorder='big'),
-                            parsed_data={'BIN_LEN': parseables.ParsedDataItem('BIN_LEN', 2, None)}),
+         0b0011010000110010010100110000000001001011000000000100100100000000.to_bytes(length=8, byteorder='big'),
          b'42'),
     ]
 )
-def test_binary_parameter_parsing(parameter_type, packet, expected):
+def test_binary_parameter_parsing(parameter_type, raw_data, expected):
     """Test parsing binary parameters"""
+    # pre parsed data to reference for lookups
+    packet = parseables.CCSDSPacket(raw_data=raw_data, **{
+        'P1': parseables.ParsedDataItem('P1', 1, None, 7.4),
+        'BIN_LEN': parseables.ParsedDataItem('BIN_LEN', 2, None)})
     raw, _ = parameter_type.parse_value(packet)
     assert raw == expected
 
@@ -1826,42 +1859,50 @@ def test_boolean_parameter_type(xml_string, expectation):
 
 
 @pytest.mark.parametrize(
-    ('parameter_type', 'packet', 'expected_raw', 'expected_derived'),
+    ('parameter_type', 'raw_data', 'current_pos', 'expected_raw', 'expected_derived'),
     [
         (parameters.BooleanParameterType(
             'TEST_BOOL',
             encodings.BinaryDataEncoding(fixed_size_in_bits=1)),
-         parseables.Packet(0b0011010000110010010100110000000001001011000000000100100100000000.to_bytes(length=64, byteorder='big')),
+         0b0011010000110010010100110000000001001011000000000100100100000000.to_bytes(length=64, byteorder='big'),
+         0,
          b'\x00', True),
         (parameters.BooleanParameterType(
             'TEST_BOOL',
             encodings.StringDataEncoding(encoding="UTF-8", termination_character='00')),
-         parseables.Packet(0b011001100110000101101100011100110110010101011111011010010111001101011111011101000111001001110101011101000110100001111001000000000010101101010111.to_bytes(length=18, byteorder='big')),
+         0b011001100110000101101100011100110110010101011111011010010111001101011111011101000111001001110101011101000110100001111001000000000010101101010111.to_bytes(length=18, byteorder='big'),
+         0,
          'false_is_truthy', True),
         (parameters.BooleanParameterType(
             'TEST_BOOL',
             encodings.IntegerDataEncoding(size_in_bits=2, encoding="unsigned")),
-         parseables.Packet(0b0011.to_bytes(length=1, byteorder='big')),
+         0b0011.to_bytes(length=1, byteorder='big'),
+         0,
          0, False),
         (parameters.BooleanParameterType(
             'TEST_BOOL',
             encodings.IntegerDataEncoding(size_in_bits=2, encoding="unsigned")),
-         parseables.Packet(0b00001111.to_bytes(length=1, byteorder='big'), pos=4),
+         0b00001111.to_bytes(length=1, byteorder='big'),
+         4,
          3, True),
         (parameters.BooleanParameterType(
             'TEST_BOOL',
             encodings.FloatDataEncoding(size_in_bits=16)),
-         parseables.Packet(0b01010001010000001111111110000000.to_bytes(length=4, byteorder='big')),
+         0b01010001010000001111111110000000.to_bytes(length=4, byteorder='big'),
+         0,
          42.0, True),
         (parameters.BooleanParameterType(
             'TEST_BOOL',
             encodings.FloatDataEncoding(size_in_bits=16)),
-         parseables.Packet(0b00000000101000101000000111111111.to_bytes(length=4, byteorder='big'), pos=7),
+         0b00000000101000101000000111111111.to_bytes(length=4, byteorder='big'),
+         7,
          42.0, True),
     ]
 )
-def test_boolean_parameter_parsing(parameter_type, packet, expected_raw, expected_derived):
+def test_boolean_parameter_parsing(parameter_type, raw_data, current_pos, expected_raw, expected_derived):
     """Test parsing boolean parameters"""
+    packet = parseables.CCSDSPacket(raw_data=raw_data)
+    packet.raw_data.pos = current_pos
     raw, derived = parameter_type.parse_value(packet)
     assert raw == expected_raw
     assert derived == expected_derived
@@ -1970,13 +2011,14 @@ def test_absolute_time_parameter_type(xml_string, expectation):
 
 
 @pytest.mark.parametrize(
-    ('parameter_type', 'packet', 'expected_raw', 'expected_derived'),
+    ('parameter_type', 'raw_data', 'current_pos', 'expected_raw', 'expected_derived'),
     [
         (parameters.AbsoluteTimeParameterType(name='TEST_PARAM_Type', unit='seconds',
                                            encoding=encodings.IntegerDataEncoding(size_in_bits=32, encoding="unsigned"),
                                            epoch="TAI", offset_from="MilliSeconds"),
          # Exactly 64 bits so neatly goes into a bytes object without padding
-         parseables.Packet(0b0011010000110010010100110000000001001011000000000100100100000000.to_bytes(length=8, byteorder='big')),
+         0b0011010000110010010100110000000001001011000000000100100100000000.to_bytes(length=8, byteorder='big'),
+         0,
          875713280, 875713280),
         (parameters.AbsoluteTimeParameterType(
              name='TEST_PARAM_Type', unit='s',
@@ -1989,7 +2031,8 @@ def test_absolute_time_parameter_type(xml_string, expectation):
                      ])),
              epoch="2009-10-10T12:00:00-05:00", offset_from="MilliSeconds"),
          # Exactly 64 bits so neatly goes into a bytes object without padding
-         parseables.Packet(0b0011010000110010010100110000000001001011000000000100100100000000.to_bytes(length=8, byteorder='big')),
+         0b0011010000110010010100110000000001001011000000000100100100000000.to_bytes(length=8, byteorder='big'),
+         0,
          875713280, 875.7132799999999),
         (parameters.AbsoluteTimeParameterType(
              name='TEST_PARAM_Type', unit='s',
@@ -2002,11 +2045,14 @@ def test_absolute_time_parameter_type(xml_string, expectation):
                      ]))),
          # 65 bits, so we need a 9th byte with 7 bits of padding to hold it,
          # which means we need to be starting at pos=7
-         parseables.Packet(0b01000000010010010000111111011011001001011000000000100100100000000.to_bytes(length=9, byteorder='big'), pos=7),
+         0b01000000010010010000111111011011001001011000000000100100100000000.to_bytes(length=9, byteorder='big'),
+         7,
          3.1415927, 151.02559269999998),
     ]
 )
-def test_absolute_time_parameter_parsing(parameter_type, packet, expected_raw, expected_derived):
+def test_absolute_time_parameter_parsing(parameter_type, raw_data, current_pos, expected_raw, expected_derived):
+    packet = parseables.CCSDSPacket(raw_data=raw_data)
+    packet.raw_data.pos = current_pos
     raw, derived = parameter_type.parse_value(packet)
     assert raw == pytest.approx(expected_raw, rel=1E-6)
     # NOTE: derived values are rounded for comparison due to imprecise storage of floats


### PR DESCRIPTION
This allows a user to index directly into the packet itself. Rather than being defined by the raw bytes.

Separate out the raw packet data from the packet object itself to keep these as two separate things.

## Checklist
- [x] Changes are fully implemented without dangling issues or TODO items
- [n/a] Deprecated/superseded code is removed or marked with deprecation warning
- [n/a] Current dependencies have been properly specified and old dependencies removed
- [x] New code/functionality has accompanying tests and any old tests have been updated to match any new assumptions
- [x] The changelog.md has been updated
