### PR TITLE
MNT: Turn some position arguments into keyword-only

### DIFF
--- a/space_packet_parser/comparisons.py
+++ b/space_packet_parser/comparisons.py
@@ -215,6 +215,7 @@ class Condition(MatchCriteria):
     def __init__(self,
                  left_param: str,
                  operator: str,
+                 *,
                  right_param: Optional[str] = None,
                  right_value: Optional[Any] = None,
                  left_use_calibrated_value: bool = True,

--- a/space_packet_parser/encodings.py
+++ b/space_packet_parser/encodings.py
@@ -171,7 +171,8 @@ class StringDataEncoding(DataEncoding):
     _supported_encodings = ('US-ASCII', 'ISO-8859-1', 'Windows-1252', 'UTF-8', 'UTF-16',
                             'UTF-16LE', 'UTF-16BE', 'UTF-32', 'UTF-32LE', 'UTF-32BE')
 
-    def __init__(self, encoding: str = 'UTF-8',
+    def __init__(self, *,
+                 encoding: str = 'UTF-8',
                  byte_order: Optional[str] = None,
                  termination_character: Optional[str] = None,
                  fixed_length: Optional[int] = None,
@@ -411,6 +412,7 @@ class NumericDataEncoding(DataEncoding, metaclass=ABCMeta):
 
     def __init__(self, size_in_bits: int,
                  encoding: str,
+                 *,
                  byte_order: str = "mostSignificantByteFirst",
                  default_calibrator: Optional[calibrators.Calibrator] = None,
                  context_calibrators: Optional[List[calibrators.ContextCalibrator]] = None):
@@ -550,7 +552,9 @@ class FloatDataEncoding(NumericDataEncoding):
     """<xtce:FloatDataEncoding>"""
     _supported_encodings = ['IEEE-754', 'MIL-1750A']
 
-    def __init__(self, size_in_bits: int, encoding: str = 'IEEE-754',
+    def __init__(self, size_in_bits: int,
+                 *,
+                 encoding: str = 'IEEE-754',
                  byte_order: str = 'mostSignificantByteFirst',
                  default_calibrator: Optional[calibrators.Calibrator] = None,
                  context_calibrators: Optional[List[calibrators.ContextCalibrator]] = None):
@@ -666,7 +670,9 @@ class FloatDataEncoding(NumericDataEncoding):
 class BinaryDataEncoding(DataEncoding):
     """<xtce:BinaryDataEncoding>"""
 
-    def __init__(self, fixed_size_in_bits: Optional[int] = None,
+    def __init__(self,
+                 *,
+                 fixed_size_in_bits: Optional[int] = None,
                  size_reference_parameter: Optional[str] = None, use_calibrated_value: bool = True,
                  size_discrete_lookup_list: Optional[List[comparisons.DiscreteLookup]] = None,
                  linear_adjuster: Optional[callable] = None):

--- a/space_packet_parser/parameters.py
+++ b/space_packet_parser/parameters.py
@@ -317,8 +317,11 @@ class BooleanParameterType(ParameterType):
 class TimeParameterType(ParameterType, metaclass=ABCMeta):
     """Abstract class for time parameter types"""
 
-    def __init__(self, name: str, encoding: encodings.DataEncoding, unit: Optional[str] = None,
-                 epoch: Optional[str] = None, offset_from: Optional[str] = None):
+    def __init__(self, name: str, encoding: encodings.DataEncoding,
+                 *,
+                 unit: Optional[str] = None,
+                 epoch: Optional[str] = None,
+                 offset_from: Optional[str] = None):
         """Constructor
 
         Parameters
@@ -369,7 +372,7 @@ class TimeParameterType(ParameterType, metaclass=ABCMeta):
             encoding.default_calibrator = encoding_unit_scaler
         epoch = cls.get_epoch(element, ns)
         offset_from = cls.get_offset_from(element, ns)
-        return cls(name, encoding, unit, epoch, offset_from)
+        return cls(name, encoding, unit=unit, epoch=epoch, offset_from=offset_from)
 
     @staticmethod
     def get_units(parameter_type_element: ElementTree.Element, ns: dict) -> Union[str, None]:

--- a/space_packet_parser/parser.py
+++ b/space_packet_parser/parser.py
@@ -236,7 +236,7 @@ class PacketParser:
         return packet
 
     @staticmethod
-    def print_progress(current_bytes: int, total_bytes: Optional[int],
+    def print_progress(*, current_bytes: int, total_bytes: Optional[int],
                        start_time_ns: int, current_packets: int,
                        end: str = '\r', log: bool = False):
         """Prints a progress bar, including statistics on parsing rate.
@@ -280,6 +280,7 @@ class PacketParser:
 
     def generator(self,  # pylint: disable=too-many-branches,too-many-statements
                   binary_data: Union[BinaryIO, socket.socket],
+                  *,
                   parse_bad_pkts: bool = True,
                   skip_header_bits: int = 0,
                   root_container_name="CCSDSPacket",


### PR DESCRIPTION
This makes some parameters keyword only as an alternative to skipping the linter altogether. If we go down this path, we should probably make some other parameters keyword only too and not just the ones to satisfy the linter.

closes #76 

## Checklist
- [x] Changes are fully implemented without dangling issues or TODO items
- [x] Deprecated/superseded code is removed or marked with deprecation warning
- [x] Current dependencies have been properly specified and old dependencies removed
- [x] New code/functionality has accompanying tests and any old tests have been updated to match any new assumptions
- [x] The changelog.md has been updated
