### PR TITLE
MNT: Use built-in types for return data objects

### DIFF
--- a/docs/source/changelog.md
+++ b/docs/source/changelog.md
@@ -17,6 +17,9 @@ Release notes for the `space_packet_parser` library
   - Much faster parsing speed
   - Users that are passing `bitstring.ConstBitStream` objects to `generator` will need to pass a 
     binary filelike object instead
+- BREAKING: The ``ParsedDataItem`` class has been removed and the derived values are being returned now.
+  The ``raw_value`` is stored as an attribute on the returned object. The other items can be accessed
+  through the packet definition object ``my_packet_definition.named_parameters["my_item"].short_description``
 - BREAKING: The return type of BinaryDataEncoding is now the raw bytes.
   To get the previous behavior you can convert the data to an integer and then format it as a binary string.
   ``f"{int.from_bytes(data, byteorder='big'):0{len(data)*8}b}"``

--- a/space_packet_parser/comparisons.py
+++ b/space_packet_parser/comparisons.py
@@ -178,7 +178,7 @@ class Comparison(MatchCriteria):
         """
         if self.referenced_parameter in packet:
             if self.use_calibrated_value:
-                parsed_value = packet[self.referenced_parameter].derived_value
+                parsed_value = packet[self.referenced_parameter]
                 if not parsed_value:
                     raise ComparisonError(f"Comparison {self} was instructed to useCalibratedValue (the default)"
                                           f"but {self.referenced_parameter} does not appear to have a derived value.")
@@ -341,7 +341,7 @@ class Condition(MatchCriteria):
         def _get_parsed_value(parameter_name: str, use_calibrated: bool):
             """Retrieves the previously parsed value from the passed in packet"""
             try:
-                return packet[parameter_name].derived_value if use_calibrated \
+                return packet[parameter_name] if use_calibrated \
                     else packet[parameter_name].raw_value
             except KeyError as e:
                 raise ComparisonError(f"Attempting to perform a Condition evaluation on {self.left_param} but "

--- a/space_packet_parser/definitions.py
+++ b/space_packet_parser/definitions.py
@@ -370,10 +370,8 @@ class XtcePacketDefinition:
         header = {}
         current_bit = 0
         for item in CCSDS_HEADER_DEFINITION:
-            header[item.name] = packets.ParsedDataItem(
-                name=item.name,
-                # pylint: disable=protected-access
-                raw_value=packets._extract_bits(packet_data, current_bit, item.nbits))
+            # pylint: disable=protected-access
+            header[item.name] = packets._extract_bits(packet_data, current_bit, item.nbits)
             current_bit += item.nbits
         return header
 
@@ -417,7 +415,7 @@ class XtcePacketDefinition:
                     raise UnrecognizedPacketTypeError(
                         f"Detected an abstract container with no valid inheritors by restriction criteria. This might "
                         f"mean this packet type is not accounted for in the provided packet definition. "
-                        f"APID={packet['PKT_APID'].raw_value}.",
+                        f"APID={packet['PKT_APID']}.",
                         partial_data=packet)
                 break
 
@@ -593,7 +591,7 @@ class XtcePacketDefinition:
             # per the CCSDS spec
             # 4.1.3.5.3 The length count C shall be expressed as:
             #   C = (Total Number of Octets in the Packet Data Field) – 1
-            n_bytes_data = header['PKT_LEN'].raw_value + 1
+            n_bytes_data = header['PKT_LEN'] + 1
             n_bytes_packet = CCSDS_HEADER_LENGTH_BYTES + n_bytes_data
 
             # Based on PKT_LEN fill buffer enough to read a full packet
@@ -623,17 +621,17 @@ class XtcePacketDefinition:
                 packet = self.parse_ccsds_packet(packet,
                                                  root_container_name=root_container_name)
             except UnrecognizedPacketTypeError as e:
-                logger.debug(f"Unrecognized error on packet with APID {header['PKT_APID'].raw_value}'")
+                logger.debug(f"Unrecognized error on packet with APID {header['PKT_APID']}'")
                 if yield_unrecognized_packet_errors:
                     # Yield the caught exception without raising it (raising ends generator)
                     yield e
                 # Continue to next packet
                 continue
 
-            if packet.header['PKT_LEN'].raw_value != header['PKT_LEN'].raw_value:
+            if packet.header['PKT_LEN'] != header['PKT_LEN']:
                 raise ValueError(f"Hardcoded header parsing found a different packet length "
-                                 f"{header['PKT_LEN'].raw_value} than the definition-based parsing found "
-                                 f"{packet.header['PKT_LEN'].raw_value}. This might be because the CCSDS header is "
+                                 f"{header['PKT_LEN']} than the definition-based parsing found "
+                                 f"{packet.header['PKT_LEN']}. This might be because the CCSDS header is "
                                  f"incorrectly represented in your packet definition document.")
 
             actual_length_parsed = packet.raw_data.pos // 8
@@ -644,7 +642,7 @@ class XtcePacketDefinition:
                                f"Updating the position to the correct position "
                                "indicated by CCSDS header.")
                 if not parse_bad_pkts:
-                    logger.warning(f"Skipping (not yielding) bad packet with apid {header['PKT_APID'].raw_value}.")
+                    logger.warning(f"Skipping (not yielding) bad packet with apid {header['PKT_APID']}.")
                     continue
 
             yield packet

--- a/tests/integration/test_xtce_based_parsing/test_jpss_parsing.py
+++ b/tests/integration/test_xtce_based_parsing/test_jpss_parsing.py
@@ -9,6 +9,9 @@ def test_jpss_xtce_packet_parsing(jpss_test_data_dir):
     jpss_xtce = jpss_test_data_dir / 'jpss1_geolocation_xtce_v1.xml'
     jpss_definition = definitions.XtcePacketDefinition(xtce_document=jpss_xtce)
     assert isinstance(jpss_definition, definitions.XtcePacketDefinition)
+    assert jpss_definition.named_parameters['USEC'].short_description == "Secondary Header Fine Time (microsecond)"
+    assert jpss_definition.named_parameters['USEC'].long_description == "CCSDS Packet 2nd Header Fine Time in microseconds."
+            
 
     jpss_packet_file = jpss_test_data_dir / 'J01_G011_LZ_2021-04-09T00-00-00Z_V01.DAT1'
 
@@ -20,7 +23,5 @@ def test_jpss_xtce_packet_parsing(jpss_test_data_dir):
             assert isinstance(jpss_packet, packets.CCSDSPacket)
             assert jpss_packet.header['PKT_APID'].raw_value == 11
             assert jpss_packet.header['VERSION'].raw_value == 0
-            assert jpss_packet['USEC'].short_description == "Secondary Header Fine Time (microsecond)"
-            assert jpss_packet['USEC'].long_description == "CCSDS Packet 2nd Header Fine Time in microseconds."
             n_packets += 1
         assert n_packets == 7200

--- a/tests/unit/test_packets.py
+++ b/tests/unit/test_packets.py
@@ -49,23 +49,3 @@ def test_ccsds_packet():
 
     with pytest.raises(KeyError):
         packet[10]
-
-
-@pytest.mark.parametrize(
-    ('name', 'raw_value', 'unit', 'derived_value', 'short_description', 'long_description', 'valid'),
-    [
-        ('TEST', 0, 'smoots', 10, "short", "long", True),
-        ('TEST', 10, None, None, None, None, True),
-        (None, 10, 'foo', 10, None, None, False),
-        ('TEST', None, None, None, None, None, False)
-    ]
-)
-def test_parsed_data_item(name, raw_value, unit, derived_value, short_description, long_description, valid):
-    """Test ParsedDataItem"""
-    pdi = packets.ParsedDataItem(name, raw_value, unit, derived_value, short_description, long_description)
-    assert pdi.name == name
-    assert pdi.raw_value == raw_value
-    assert pdi.unit == unit
-    assert pdi.derived_value == derived_value
-    assert pdi.short_description == short_description
-    assert pdi.long_description == long_description

--- a/tests/unit/test_xtcedef.py
+++ b/tests/unit/test_xtcedef.py
@@ -122,82 +122,82 @@ def test_attr_comparable():
 <xtce:Comparison xmlns:xtce="http://www.omg.org/space/xtce" 
     comparisonOperator="==" value="678" parameterRef="MSN__PARAM"/>
 """,
-         {'MSN__PARAM': packets.ParsedDataItem('MSN__PARAM', 3, None, 678)}, None, True),
+         {'MSN__PARAM': packets.FloatParameter(678, 3)}, None, True),
         ("""
 <xtce:Comparison xmlns:xtce="http://www.omg.org/space/xtce" 
     comparisonOperator="eq" value="678" parameterRef="MSN__PARAM"/>
 """,
-         {'MSN__PARAM': packets.ParsedDataItem('MSN__PARAM', 3, None, 668)}, None, False),
+         {'MSN__PARAM': packets.FloatParameter(668, 3)}, None, False),
         ("""
 <xtce:Comparison xmlns:xtce="http://www.omg.org/space/xtce" 
     comparisonOperator="!=" value="678" parameterRef="MSN__PARAM"/>
 """,
-         {'MSN__PARAM': packets.ParsedDataItem('MSN__PARAM', 3, None, 678)}, None, False),
+         {'MSN__PARAM': packets.FloatParameter(678, 3)}, None, False),
         ("""
 <xtce:Comparison xmlns:xtce="http://www.omg.org/space/xtce" 
     comparisonOperator="neq" value="678" parameterRef="MSN__PARAM"/>
 """,
-         {'MSN__PARAM': packets.ParsedDataItem('MSN__PARAM', 3, None, 658)}, None, True),
+         {'MSN__PARAM': packets.FloatParameter(658, 3)}, None, True),
         ("""
 <xtce:Comparison xmlns:xtce="http://www.omg.org/space/xtce" 
     comparisonOperator="&lt;" value="678" parameterRef="MSN__PARAM"/>
 """,
-         {'MSN__PARAM': packets.ParsedDataItem('MSN__PARAM', 3, None, 679)}, None, False),
+         {'MSN__PARAM': packets.FloatParameter(679, 3)}, None, False),
         ("""
 <xtce:Comparison xmlns:xtce="http://www.omg.org/space/xtce" 
     comparisonOperator="lt" value="678" parameterRef="MSN__PARAM"/>
 """,
-         {'MSN__PARAM': packets.ParsedDataItem('MSN__PARAM', 3, None, 670)}, None, True),
+         {'MSN__PARAM': packets.FloatParameter(670, 3)}, None, True),
         ("""
 <xtce:Comparison xmlns:xtce="http://www.omg.org/space/xtce" 
     comparisonOperator="&gt;" value="678" parameterRef="MSN__PARAM"/>
 """,
-         {'MSN__PARAM': packets.ParsedDataItem('MSN__PARAM', 3, None, 678)}, None, False),
+         {'MSN__PARAM': packets.FloatParameter(678, 3)}, None, False),
         ("""
 <xtce:Comparison xmlns:xtce="http://www.omg.org/space/xtce" 
     comparisonOperator="gt" value="678" parameterRef="MSN__PARAM"/>
 """,
-         {'MSN__PARAM': packets.ParsedDataItem('MSN__PARAM', 3, None, 679)}, None, True),
+         {'MSN__PARAM': packets.FloatParameter(679, 3)}, None, True),
         ("""
 <xtce:Comparison xmlns:xtce="http://www.omg.org/space/xtce" 
     comparisonOperator="&lt;=" value="678" parameterRef="MSN__PARAM"/>
 """,
-         {'MSN__PARAM': packets.ParsedDataItem('MSN__PARAM', 3, None, 660)}, None, True),
+         {'MSN__PARAM': packets.FloatParameter(660, 3)}, None, True),
         ("""
 <xtce:Comparison xmlns:xtce="http://www.omg.org/space/xtce" 
     comparisonOperator="leq" value="678" parameterRef="MSN__PARAM"/>
 """,
-         {'MSN__PARAM': packets.ParsedDataItem('MSN__PARAM', 3, None, 690)}, None, False),
+         {'MSN__PARAM': packets.FloatParameter(690, 3)}, None, False),
         ("""
 <xtce:Comparison xmlns:xtce="http://www.omg.org/space/xtce" 
     comparisonOperator="&gt;=" value="678" parameterRef="MSN__PARAM"/>
 """,
-         {'MSN__PARAM': packets.ParsedDataItem('MSN__PARAM', 3, None, 660)}, None, False),
+         {'MSN__PARAM': packets.FloatParameter(660, 3)}, None, False),
         ("""
 <xtce:Comparison xmlns:xtce="http://www.omg.org/space/xtce" 
     comparisonOperator="geq" value="678" parameterRef="MSN__PARAM"/>
 """,
-         {'MSN__PARAM': packets.ParsedDataItem('MSN__PARAM', 3, None, 690)}, None, True),
+         {'MSN__PARAM': packets.FloatParameter(690, 3)}, None, True),
         ("""
 <xtce:Comparison xmlns:xtce="http://www.omg.org/space/xtce" 
     comparisonOperator="==" value="678" parameterRef="MSN__PARAM" useCalibratedValue="false"/>
 """,
-         {'MSN__PARAM': packets.ParsedDataItem('MSN__PARAM', 678, None, 690)}, None, True),
+         {'MSN__PARAM': packets.FloatParameter(690, 678)}, None, True),
         ("""
 <xtce:Comparison xmlns:xtce="http://www.omg.org/space/xtce" 
     comparisonOperator="==" value="678" parameterRef="MSN__PARAM" useCalibratedValue="true"/>
 """,
-         {'MSN__PARAM': packets.ParsedDataItem('MSN__PARAM', 3, None, 678)}, None, True),
+         {'MSN__PARAM': packets.FloatParameter(678, 3)}, None, True),
         ("""
 <xtce:Comparison xmlns:xtce="http://www.omg.org/space/xtce" 
     comparisonOperator="==" value="foostring" parameterRef="MSN__PARAM" useCalibratedValue="false"/>
 """,
-         {'MSN__PARAM': packets.ParsedDataItem('MSN__PARAM', 'foostring', None, 'calibratedfoostring')}, None, True),
+         {'MSN__PARAM': packets.StrParameter('calibratedfoostring', 'foostring')}, None, True),
         ("""
 <xtce:Comparison xmlns:xtce="http://www.omg.org/space/xtce" 
     comparisonOperator="==" value="3.14" parameterRef="MSN__PARAM"/>
 """,
-         {'MSN__PARAM': packets.ParsedDataItem('MSN__PARAM', 1, None, 3.14)}, None, True),
+         {'MSN__PARAM': packets.FloatParameter(3.14, 1)}, None, True),
         ("""
 <xtce:Comparison xmlns:xtce="http://www.omg.org/space/xtce" 
     comparisonOperator="==" value="3.0" parameterRef="REFERENCE_TO_OWN_RAW_VAL"/>
@@ -242,8 +242,8 @@ def test_comparison(xml_string, test_parsed_data, current_parsed_value, expected
     <xtce:ParameterInstanceRef parameterRef="P2"/>
 </xtce:Condition>
 """,
-         {'P1': packets.ParsedDataItem('P1', 4, None, 700),
-          'P2': packets.ParsedDataItem('P2', 3, None, 678)}, True),
+         {'P1': packets.IntParameter(700, 4),
+          'P2': packets.IntParameter(678, 3)}, True),
         ("""
 <xtce:Condition xmlns:xtce="http://www.omg.org/space/xtce">
     <xtce:ParameterInstanceRef parameterRef="P1"/>
@@ -251,7 +251,7 @@ def test_comparison(xml_string, test_parsed_data, current_parsed_value, expected
     <xtce:Value>4</xtce:Value>
 </xtce:Condition>
 """,
-         {'P1': packets.ParsedDataItem('P1', 4, None, 700)}, True),
+         {'P1': packets.IntParameter(700, 4)}, True),
         ("""
 <xtce:Condition xmlns:xtce="http://www.omg.org/space/xtce">
     <xtce:ParameterInstanceRef parameterRef="P1"/>
@@ -259,8 +259,8 @@ def test_comparison(xml_string, test_parsed_data, current_parsed_value, expected
     <xtce:ParameterInstanceRef parameterRef="P2"/>
 </xtce:Condition>
 """,
-         {'P1': packets.ParsedDataItem('P1', 4, None, 700),
-          'P2': packets.ParsedDataItem('P2', 3, None, 678)}, False),
+         {'P1': packets.IntParameter(700, 4),
+          'P2': packets.IntParameter(678, 3)}, False),
         ("""
 <xtce:Condition xmlns:xtce="http://www.omg.org/space/xtce">
     <xtce:ParameterInstanceRef parameterRef="P1" useCalibratedValue="false"/>
@@ -268,8 +268,8 @@ def test_comparison(xml_string, test_parsed_data, current_parsed_value, expected
     <xtce:ParameterInstanceRef parameterRef="P2" useCalibratedValue="false"/>
 </xtce:Condition>
 """,
-         {'P1': packets.ParsedDataItem('P1', 'abcd', None),
-          'P2': packets.ParsedDataItem('P2', 'abcd', None)}, True),
+         {'P1': packets.StrParameter('abcd'),
+          'P2': packets.StrParameter('abcd')}, True),
         ("""
 <xtce:Condition xmlns:xtce="http://www.omg.org/space/xtce">
     <xtce:ParameterInstanceRef parameterRef="P1"/>
@@ -277,8 +277,8 @@ def test_comparison(xml_string, test_parsed_data, current_parsed_value, expected
     <xtce:ParameterInstanceRef parameterRef="P2"/>
 </xtce:Condition>
 """,
-         {'P1': packets.ParsedDataItem('P1', 1, None, 3.14),
-          'P2': packets.ParsedDataItem('P2', 180, None, 3.14)}, True),
+         {'P1': packets.FloatParameter(3.14, 1),
+          'P2': packets.FloatParameter(3.14, 180)}, True),
     ]
 )
 def test_condition(xml_string, test_parsed_data, expected_condition_result):
@@ -314,10 +314,10 @@ def test_condition(xml_string, test_parsed_data, expected_condition_result):
     </xtce:ORedConditions>
 </xtce:BooleanExpression>
 """,
-         {'P': packets.ParsedDataItem('P', 4, None, 0),
-          'P2': packets.ParsedDataItem('P2', 4, None, 700),
-          'P3': packets.ParsedDataItem('P3', 4, None, 701),
-          'P4': packets.ParsedDataItem('P4', 4, None, 98)}, True),
+         {'P': packets.IntParameter(0, 4),
+          'P2': packets.IntParameter(700, 4),
+          'P3': packets.IntParameter(701, 4),
+          'P4': packets.IntParameter(98, 4)}, True),
         ("""
 <xtce:BooleanExpression xmlns:xtce="http://www.omg.org/space/xtce">
     <xtce:ANDedConditions>
@@ -346,12 +346,12 @@ def test_condition(xml_string, test_parsed_data, expected_condition_result):
     </xtce:ANDedConditions>
 </xtce:BooleanExpression>
 """,
-         {'P': packets.ParsedDataItem('P', 4, None, 100),
-          'P0': packets.ParsedDataItem('P0', 4, None, 678),
-          'P1': packets.ParsedDataItem('P1', 4, None, 500),
-          'P2': packets.ParsedDataItem('P2', 4, None, 700),
-          'P3': packets.ParsedDataItem('P3', 4, None, 701),
-          'P4': packets.ParsedDataItem('P4', 4, None, 99)}, True),
+         {'P': packets.IntParameter(100, 4),
+          'P0': packets.IntParameter(678, 4),
+          'P1': packets.IntParameter(500, 4),
+          'P2': packets.IntParameter(700, 4),
+          'P3': packets.IntParameter(701, 4),
+          'P4': packets.IntParameter(99, 4)}, True),
     ]
 )
 def test_boolean_expression(xml_string, test_parsed_data, expected_result):
@@ -373,13 +373,13 @@ def test_boolean_expression(xml_string, test_parsed_data, expected_result):
     <xtce:Comparison useCalibratedValue="false" parameterRef="P1" value="1"/>
 </xtce:DiscreteLookup>
 """,
-         {'P1': packets.ParsedDataItem('P1', 1, None, 678)}, 10),
+         {'P1': packets.IntParameter(678, 1)}, 10),
         ("""
 <xtce:DiscreteLookup value="10" xmlns:xtce="http://www.omg.org/space/xtce">
     <xtce:Comparison useCalibratedValue="false" parameterRef="P1" value="1"/>
 </xtce:DiscreteLookup>
 """,
-         {'P1': packets.ParsedDataItem('P1', 0, None, 678)}, None),
+         {'P1': packets.IntParameter(678, 0)}, None),
         ("""
 <xtce:DiscreteLookup value="11" xmlns:xtce="http://www.omg.org/space/xtce">
     <xtce:ComparisonList>
@@ -389,8 +389,8 @@ def test_boolean_expression(xml_string, test_parsed_data, expected_result):
 </xtce:DiscreteLookup>
 """,
          {
-             'MSN__PARAM1': packets.ParsedDataItem('MSN__PARAM1', 3, None, 680),
-             'MSN__PARAM2': packets.ParsedDataItem('MSN__PARAM2', 3, None, 3000)
+             'MSN__PARAM1': packets.IntParameter(680, 3),
+             'MSN__PARAM2': packets.IntParameter(3000, 3),
          }, 11),
     ]
 )
@@ -536,7 +536,7 @@ def test_context_calibrator(xml_string, expectation):
                 calibrators.PolynomialCoefficient(coefficient=0.5, exponent=0),
                 calibrators.PolynomialCoefficient(coefficient=1.5, exponent=1)
             ])),
-         {"EXI__FPGAT": packets.ParsedDataItem("EXI__FPGAT", 600, derived_value=700)},
+         {"EXI__FPGAT": packets.IntParameter(700, 600)},
          42, True, 63.5),
         (calibrators.ContextCalibrator(
             match_criteria=[
@@ -547,7 +547,7 @@ def test_context_calibrator(xml_string, expectation):
                 calibrators.PolynomialCoefficient(coefficient=0.5, exponent=0),
                 calibrators.PolynomialCoefficient(coefficient=1.5, exponent=1),
             ])),
-         {"EXI__FPGAT": packets.ParsedDataItem("EXI__FPGAT", 3.14, derived_value=700.0)},
+         {"EXI__FPGAT": packets.FloatParameter(700.0, 3.14)},
          42, True, 63.5),
         (calibrators.ContextCalibrator(
             match_criteria=[
@@ -567,8 +567,8 @@ def test_context_calibrator(xml_string, expectation):
                 calibrators.PolynomialCoefficient(coefficient=0.5, exponent=0),
                 calibrators.PolynomialCoefficient(coefficient=1.5, exponent=1),
             ])),
-         {"P1": packets.ParsedDataItem("P1", 100.0, derived_value=700.0),
-          "P2": packets.ParsedDataItem("P2", 99, derived_value=700.0)},
+         {"P1": packets.FloatParameter(700.0, 100.0),
+          "P2": packets.FloatParameter(700.0, 99)},
          42, True, 63.5),
         (calibrators.ContextCalibrator(
             match_criteria=[
@@ -589,8 +589,8 @@ def test_context_calibrator(xml_string, expectation):
                 calibrators.PolynomialCoefficient(coefficient=0.5, exponent=0),
                 calibrators.PolynomialCoefficient(coefficient=1.5, exponent=1),
             ])),
-         {"P1": packets.ParsedDataItem("P1", 100.0, derived_value=700.0),
-          "P2": packets.ParsedDataItem("P2", 99, derived_value=700.0)},
+         {"P1": packets.FloatParameter(700.0, 100.0),
+          "P2": packets.FloatParameter(700.0, 99)},
          42, False, 63.5),
     ]
 )
@@ -1313,14 +1313,14 @@ def test_string_parameter_type(xml_string: str, expectation):
 def test_string_parameter_parsing(parameter_type, raw_data, current_pos, expected_raw, expected_derived):
     """Test parsing a string parameter"""
     # pre parsed data to reference for lookups
-    packet = packets.CCSDSPacket(raw_data=raw_data, **{'P1': packets.ParsedDataItem('P1', 7, None, 7.55),
-                                                       'P2': packets.ParsedDataItem('P2', 99, None, 100),
-                                                       'STR_LEN': packets.ParsedDataItem('STR_LEN', 8, None)})
+    packet = packets.CCSDSPacket(raw_data=raw_data, **{'P1': packets.FloatParameter(7.55, 7),
+                                                       'P2': packets.IntParameter(100, 99),
+                                                       'STR_LEN': packets.IntParameter(8)})
     # Artificially set the current position of the packet data read so far
     packet.raw_data.pos = current_pos
-    raw, derived = parameter_type.parse_value(packet)
-    assert raw == expected_raw
-    assert derived == expected_derived
+    value = parameter_type.parse_value(packet)
+    assert value == expected_derived
+    assert value.raw_value == expected_raw
 
 
 @pytest.mark.parametrize(
@@ -1504,13 +1504,10 @@ def test_integer_parameter_type(xml_string: str, expectation):
 def test_integer_parameter_parsing(parameter_type, raw_data, current_pos, expected):
     """Testing parsing an integer parameters"""
     # pre parsed data to reference for lookups
-    packet = packets.CCSDSPacket(raw_data=raw_data, PKT_APID=packets.ParsedDataItem('PKT_APID', 1101))
+    packet = packets.CCSDSPacket(raw_data=raw_data, PKT_APID=packets.IntParameter(1101))
     packet.raw_data.pos = current_pos
-    raw, derived = parameter_type.parse_value(packet)
-    if derived:
-        assert derived == expected
-    else:
-        assert raw == expected
+    value = parameter_type.parse_value(packet)
+    assert value == expected
 
 
 @pytest.mark.parametrize(
@@ -1702,13 +1699,10 @@ def test_float_parameter_type(xml_string: str, expectation):
 def test_float_parameter_parsing(parameter_type, raw_data, expected):
     """Test parsing float parameters"""
     # pre parsed data to reference for lookups
-    packet = packets.CCSDSPacket(raw_data=raw_data, **{'PKT_APID': packets.ParsedDataItem('PKT_APID', 1101)})
-    raw, derived = parameter_type.parse_value(packet)
+    packet = packets.CCSDSPacket(raw_data=raw_data, **{'PKT_APID': packets.IntParameter(1101)})
+    value = parameter_type.parse_value(packet)
     # NOTE: These results are compared with a relative tolerance due to the imprecise storage of floats
-    if derived:
-        assert derived == pytest.approx(expected, rel=1E-7)
-    else:
-        assert raw == pytest.approx(expected, rel=1E-7)
+    assert value == pytest.approx(expected, rel=1E-7)
 
 
 @pytest.mark.parametrize(
@@ -1764,11 +1758,8 @@ def test_enumerated_parameter_type(xml_string: str, expectation):
 def test_enumerated_parameter_parsing(parameter_type, raw_data, expected):
     """"Test parsing enumerated parameters"""
     packet = packets.CCSDSPacket(raw_data=raw_data)
-    raw, derived = parameter_type.parse_value(packet)
-    if derived:
-        assert derived == expected
-    else:
-        assert raw == expected
+    value = parameter_type.parse_value(packet)
+    assert value == expected
 
 
 @pytest.mark.parametrize(
@@ -1880,10 +1871,10 @@ def test_binary_parameter_parsing(parameter_type, raw_data, expected):
     """Test parsing binary parameters"""
     # pre parsed data to reference for lookups
     packet = packets.CCSDSPacket(raw_data=raw_data, **{
-        'P1': packets.ParsedDataItem('P1', 1, None, 7.4),
-        'BIN_LEN': packets.ParsedDataItem('BIN_LEN', 2, None)})
-    raw, _ = parameter_type.parse_value(packet)
-    assert raw == expected
+        'P1': packets.FloatParameter(7.4, 1),
+        'BIN_LEN': packets.IntParameter(2)})
+    value = parameter_type.parse_value(packet)
+    assert value == expected
 
 
 @pytest.mark.parametrize(
@@ -1990,9 +1981,9 @@ def test_boolean_parameter_parsing(parameter_type, raw_data, current_pos, expect
     """Test parsing boolean parameters"""
     packet = packets.CCSDSPacket(raw_data=raw_data)
     packet.raw_data.pos = current_pos
-    raw, derived = parameter_type.parse_value(packet)
-    assert raw == expected_raw
-    assert derived == expected_derived
+    value = parameter_type.parse_value(packet)
+    assert value.raw_value == expected_raw
+    assert value == expected_derived
 
 
 @pytest.mark.parametrize(
@@ -2142,10 +2133,10 @@ def test_absolute_time_parameter_type(xml_string, expectation):
 def test_absolute_time_parameter_parsing(parameter_type, raw_data, current_pos, expected_raw, expected_derived):
     packet = packets.CCSDSPacket(raw_data=raw_data)
     packet.raw_data.pos = current_pos
-    raw, derived = parameter_type.parse_value(packet)
-    assert raw == pytest.approx(expected_raw, rel=1E-6)
+    value = parameter_type.parse_value(packet)
+    assert value.raw_value == pytest.approx(expected_raw, rel=1E-6)
     # NOTE: derived values are rounded for comparison due to imprecise storage of floats
-    assert derived == pytest.approx(expected_derived, rel=1E-6)
+    assert value == pytest.approx(expected_derived, rel=1E-6)
 
 
 # ---------------


### PR DESCRIPTION
This adds the ability to subclass the built-in types and return an item that can be acted upon directly rather than having to access `parsed_item.raw_value` as an attribute to do any work with the item.

The built-in types are immutable and can't have attributes added to them so we inject the `raw_value` attribute in the new constructor of each explicit type.

**this PR**

```
{'VERSION': 0, 'TYPE': 0, 'SEC_HDR_FLG': 1, 'PKT_APID': 1424, 'SEQ_FLGS': 3, 'SRC_SEQ_CTR': 77, 'PKT_LEN': 1065, 'SHCOARSE': 1343, 'SHFINE': 19201, ...
```

**main**
```
{'VERSION': ParsedDataItem(name='VERSION', raw_value=0, unit=None, derived_value=0, short_description=None, long_description=None), 'TYPE': ParsedDataItem(name='TYPE', raw_value=0, unit=None, derived_value=0, short_description=None, long_description=None), 'SEC_HDR_FLG': ParsedDataItem(name='SEC_HDR_FLG', raw_value=1, unit=None, derived_value=1, short_description=None, long_description=None), 'PKT_APID': ParsedDataItem(name='PKT_APID', raw_value=1424, unit=None, derived_value=1424, short_description=None, long_description=None), 'SEQ_FLGS': ParsedDataItem(name='SEQ_FLGS', raw_value=3, unit=None, derived_value=3, short_description=None, long_description=None), 'SRC_SEQ_CTR': ParsedDataItem(name='SRC_SEQ_CTR', raw_value=77, unit=None, derived_value=77, short_description=None, long_description=None), 'PKT_LEN': ParsedDataItem(name='PKT_LEN', raw_value=1065, unit=None, derived_value=1065, short_description=None, long_description=None), 'SHCOARSE': ParsedDataItem(name='SHCOARSE', raw_value=1343, unit='dn', derived_value=1343, short_description='Secondary Header Coarse Time', long_description='CCSDS Packet 2nd Header Coarse Time'), 'SHFINE': ParsedDataItem(name='SHFINE', raw_value=19201, unit='dn', derived_value=19201, short_description='Secondary Header Fine Time', long_description='CCSDS Packet 2nd Header Fine Time'), ...
```

## Checklist
- [x] Changes are fully implemented without dangling issues or TODO items
- [x] Deprecated/superseded code is removed or marked with deprecation warning
- [x] Current dependencies have been properly specified and old dependencies removed
- [x] New code/functionality has accompanying tests and any old tests have been updated to match any new assumptions
- [x] The changelog.md has been updated
