### PR TITLE
Fix bug in representing falsy raw value in parsed _Parameters

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,7 +1,7 @@
 cff-version: 1.2.0
 title: 'space_packet_parser'
 type: software
-version: '5.0.0'
+version: '5.0.1'
 description: A CCSDS telemetry packet decoding library based on the XTCE packet format description standard.
 license: BSD-3-Clause
 abstract: The Space Packet Parser Python library is a generalized, configurable packet decoding library for CCSDS telemetry

--- a/docs/source/changelog.md
+++ b/docs/source/changelog.md
@@ -5,6 +5,9 @@ list and release milestones.
 ## Version Release Notes
 Release notes for the `space_packet_parser` library
 
+### v5.0.1 (released)
+- BUGFIX: Allow raw_value representation for enums with falsy raw values. Previously these defaulted to the enum label.
+
 ### v5.0.0 (released)
 - *BREAKING*: Main API changed. No need to create separate definition and parser objects any more. Create only a 
   definition from your XTCE document and instead of `my_parser.generator`, use `my_packet_definition.packet_generator`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "space_packet_parser"
-version = "5.0.0"
+version = "5.0.1"
 description = "A CCSDS telemetry packet decoding library based on the XTCE packet format description standard."
 license = "BSD-3-Clause"
 readme = "README.md"

--- a/space_packet_parser/packets.py
+++ b/space_packet_parser/packets.py
@@ -24,7 +24,7 @@ class _Parameter:
     def __new__(cls, value: BuiltinDataTypes, raw_value: BuiltinDataTypes = None) -> BuiltinDataTypes:
         obj = super().__new__(cls, value)
         # Default to the same value as the parsed value if it isn't provided
-        obj.raw_value = raw_value or value
+        obj.raw_value = raw_value if raw_value is not None else value
         return obj
 
 


### PR DESCRIPTION
Force Boolean and Enumerated parameter parsing to key off of the raw encoded value, per XTCE spec

## Checklist
- [x] Changes are fully implemented without dangling issues or TODO items
- [NA] Deprecated/superseded code is removed or marked with deprecation warning
- [NA] Current dependencies have been properly specified and old dependencies removed
- [x] New code/functionality has accompanying tests and any old tests have been updated to match any new assumptions
- [x] The changelog.md has been updated
