### PR TITLE
MNT/ENH: Add a raw CCSDS packet generator

### DIFF
--- a/docs/source/changelog.md
+++ b/docs/source/changelog.md
@@ -14,6 +14,8 @@ Release notes for the `space_packet_parser` library
   with the given header items and data. This is useful for creating
   mock packets in testing and experimentation for creating debugging
   streams as needed.
+- Add a ``ccsds_packet_generator()`` function that iterates through raw
+  bytes and yields individual CCSDS packets.
 
 ### v5.0.1 (released)
 - BUGFIX: Allow raw_value representation for enums with falsy raw values. Previously these defaulted to the enum label.

--- a/docs/source/changelog.md
+++ b/docs/source/changelog.md
@@ -8,6 +8,12 @@ Release notes for the `space_packet_parser` library
 ### v5.1.0 (unreleased)
 - BUGFIX: Fix kbps calculation in packet generator for showing progress.
 - Add support for string and float encoded enumerated lookup parameters.
+- Add properties to extract the CCSDS Header items from the ``RawPacketData`` object directly.
+  e.g. ``RawPacketData.apid``
+- Add a ``create_ccsds_packet`` function that can create a CCSDS Packet
+  with the given header items and data. This is useful for creating
+  mock packets in testing and experimentation for creating debugging
+  streams as needed.
 
 ### v5.0.1 (released)
 - BUGFIX: Allow raw_value representation for enums with falsy raw values. Previously these defaulted to the enum label.

--- a/space_packet_parser/definitions.py
+++ b/space_packet_parser/definitions.py
@@ -324,8 +324,7 @@ class XtcePacketDefinition:
     def parse_ccsds_packet(self,
                            packet: packets.CCSDSPacket,
                            *,
-                           root_container_name: str = "CCSDSPacket",
-                           **parse_value_kwargs) -> packets.CCSDSPacket:
+                           root_container_name: str = "CCSDSPacket") -> packets.CCSDSPacket:
         """Parse binary packet data according to the self.packet_definition object
 
         Parameters
@@ -343,7 +342,7 @@ class XtcePacketDefinition:
         """
         current_container: packets.SequenceContainer = self._sequence_container_cache[root_container_name]
         while True:
-            current_container.parse(packet, **parse_value_kwargs)
+            current_container.parse(packet)
 
             valid_inheritors = []
             for inheritor_name in current_container.inheritors:

--- a/space_packet_parser/encodings.py
+++ b/space_packet_parser/encodings.py
@@ -145,7 +145,7 @@ class DataEncoding(comparisons.AttrComparable, metaclass=ABCMeta):
         """
         raise NotImplementedError()
 
-    def parse_value(self, packet: packets.CCSDSPacket, **kwargs) -> packets.ParameterDataTypes:
+    def parse_value(self, packet: packets.CCSDSPacket) -> packets.ParameterDataTypes:
         """Parse a value from packet data, possibly using previously parsed data items to inform parsing.
 
         Parameters
@@ -334,7 +334,7 @@ class StringDataEncoding(DataEncoding):
         ).to_bytes(buflen_bytes, "big")
         return raw_string_buffer
 
-    def parse_value(self, packet: packets.CCSDSPacket, **kwargs) -> packets.StrParameter:
+    def parse_value(self, packet: packets.CCSDSPacket) -> packets.StrParameter:
         """Parse a string value from packet data, possibly using previously parsed data items to inform parsing.
 
         Parameters
@@ -529,7 +529,7 @@ class NumericDataEncoding(DataEncoding, metaclass=ABCMeta):
 
     def parse_value(self,
                     packet: packets.CCSDSPacket,
-                    **kwargs) -> Union[packets.FloatParameter, packets.IntParameter]:
+                    ) -> Union[packets.FloatParameter, packets.IntParameter]:
         """Parse a value from packet data, possibly using previously parsed data items to inform parsing.
 
         Parameters
@@ -793,7 +793,7 @@ class BinaryDataEncoding(DataEncoding):
             len_bits = self.linear_adjuster(len_bits)
         return len_bits
 
-    def parse_value(self, packet: packets.CCSDSPacket, **kwargs) -> packets.BinaryParameter:
+    def parse_value(self, packet: packets.CCSDSPacket) -> packets.BinaryParameter:
         """Parse a value from packet data, possibly using previously parsed data items to inform parsing.
 
         Parameters

--- a/space_packet_parser/exceptions.py
+++ b/space_packet_parser/exceptions.py
@@ -30,3 +30,17 @@ class CalibrationError(Exception):
 class InvalidParameterTypeError(Exception):
     """Error raised when someone is using an invalid ParameterType element"""
     pass
+
+
+class UnrecognizedPacketTypeError(Exception):
+    """Error raised when we can't figure out which kind of packet we are dealing with based on the header"""
+
+    def __init__(self, *args, partial_data: dict = None):
+        """
+        Parameters
+        ----------
+        partial_data : dict, Optional
+            Data parsed so far (for debugging at higher levels)
+        """
+        super().__init__(*args)
+        self.partial_data = partial_data

--- a/space_packet_parser/packets.py
+++ b/space_packet_parser/packets.py
@@ -295,7 +295,7 @@ class CCSDSPacket(dict):
 
 class Parseable(Protocol):
     """Defines an object that can be parsed from packet data."""
-    def parse(self, packet: CCSDSPacket, **parse_value_kwargs) -> None:
+    def parse(self, packet: CCSDSPacket) -> None:
         """Parse this entry from the packet data and add the necessary items to the packet."""
 
 
@@ -336,13 +336,13 @@ class SequenceContainer(Parseable):
         self.restriction_criteria = self.restriction_criteria or []
         self.inheritors = self.inheritors or []
 
-    def parse(self, packet: CCSDSPacket, **parse_value_kwargs) -> None:
+    def parse(self, packet: CCSDSPacket) -> None:
         """Parse the entry list of parameters/containers in the order they are expected in the packet.
 
         This could be recursive if the entry list contains SequenceContainers.
         """
         for entry in self.entry_list:
-            entry.parse(packet=packet, **parse_value_kwargs)
+            entry.parse(packet=packet)
 
 
 def ccsds_generator(  # pylint: disable=too-many-branches,too-many-statements

--- a/tests/unit/test_packets.py
+++ b/tests/unit/test_packets.py
@@ -5,6 +5,58 @@ import pytest
 from space_packet_parser import packets
 
 
+@pytest.mark.parametrize(("input_var", "input_value"),
+                         [("version_number", 0), ("version_number", 7),
+                          ("type", 0), ("type", 1),
+                          ("secondary_header_flag", 0), ("secondary_header_flag", 1),
+                          ("apid", 0), ("apid", 2**11 - 1),
+                          ("sequence_flags", 0), ("sequence_flags", 3),
+                          ("sequence_count", 0), ("sequence_count", 2**14 - 1),
+                          ("data", bytes(1)), pytest.param("data", bytes(65536), id="max-bytes")])
+def test_create_ccsds_packet_input_range(input_var, input_value):
+    """Validate the min/max integer inputs"""
+    p = packets.create_ccsds_packet(**{input_var: input_value})
+    if input_var == "data":
+        assert p[6:] == input_value
+    else:
+        assert getattr(p, input_var) == input_value
+
+
+@pytest.mark.parametrize(("input_var", "input_value"),
+                         [("version_number", -1), ("version_number", 8),
+                          ("type", -1), ("type", 2),
+                          ("secondary_header_flag", -1), ("secondary_header_flag", 2),
+                          ("apid", -1), ("apid", 2**11),
+                          ("sequence_flags", -1), ("sequence_flags", 4),
+                          ("sequence_count", -1), ("sequence_count", 2**14),
+                          ("data", bytes(0)), pytest.param("data", bytes(65537), id="max-bytes")])
+def test_create_ccsds_packet_value_range_error(input_var, input_value):
+    """Validate the min/max integer inputs"""
+    with pytest.raises(ValueError):
+        packets.create_ccsds_packet(**{input_var: input_value})
+
+@pytest.mark.parametrize("input_var", ["version_number", "type", "secondary_header_flag", "apid",
+                                       "sequence_flags", "sequence_count", "data"])
+@pytest.mark.parametrize("input_value", [1.0, "1", 0.5])
+def test_create_ccsds_packet_type_validation(input_var, input_value):
+    """Only integers are allowed for the header fields and bytes for the data field."""
+    with pytest.raises(TypeError):
+        packets.create_ccsds_packet(**{input_var: input_value})
+
+
+def test_raw_packet_attributes():
+    p = packets.create_ccsds_packet(data=b"123", version_number=3, type=1, secondary_header_flag=1, 
+                                    apid=1234, sequence_flags=2, sequence_count=5)
+    assert p.version_number == 3
+    assert p.type == 1
+    assert p.secondary_header_flag == 1
+    assert p.apid == 1234
+    assert p.sequence_flags == 2
+    assert p.sequence_count == 5
+    assert len(p) == 6 + 3
+    assert p[6:] == b"123"
+
+
 @pytest.mark.parametrize(("raw_value", "start", "nbits", "expected"),
                          [(0b11000000, 0, 2, 0b11),
                           (0b11000000, 1, 2, 0b10),
@@ -19,7 +71,7 @@ from space_packet_parser import packets
                           # Multiple bytes
                           (0b110000111100001100000000, 8, 10, 0b1100001100),
                           (0b110000111100001100000000, 0, 24, 0b110000111100001100000000)])
-def test_raw_packet_data(raw_value, start, nbits, expected):
+def test_raw_packet_reads(raw_value, start, nbits, expected):
     raw_bytes = raw_value.to_bytes((raw_value.bit_length() + 7) // 8, "big")
     raw_packet = packets.RawPacketData(raw_bytes)
     raw_packet.pos = start
@@ -32,7 +84,7 @@ def test_raw_packet_data(raw_value, start, nbits, expected):
     assert raw_packet.pos == start + nbits
 
 
-def test_ccsds_packet():
+def test_ccsds_packet_data_lookups():
     packet = packets.CCSDSPacket(raw_data=b"123")
     assert packet.raw_data == b"123"
     # There are no items yet, so it should be an empty dictionary


### PR DESCRIPTION
This refactors out the reading of a byte-stream into a separate generator function that can yield raw CCSDSPackets with only the raw bytes. The definitions and parsing logic can use this generator to yield packets and then parse whatever they need to after the fact. This enables someone to use this generator without a packet definition and to investigate what is in the packet stream without needing to know more detailed information about how individual packets are laid out internally.

closes #81
closes #104

## Checklist
- [x] Changes are fully implemented without dangling issues or TODO items
- [x] Deprecated/superseded code is removed or marked with deprecation warning
- [x] Current dependencies have been properly specified and old dependencies removed
- [x] New code/functionality has accompanying tests and any old tests have been updated to match any new assumptions
- [x] The changelog.md has been updated
