### PR TITLE
ENH: Add an Excel spreadsheet to XTCE conversion utility

### DIFF
--- a/.github/workflows/pr_tests.yml
+++ b/.github/workflows/pr_tests.yml
@@ -27,7 +27,7 @@ jobs:
     strategy:
       matrix:
         os: [windows-latest, ubuntu-latest, macos-latest]
-        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13-dev']
+        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
     defaults:
       run:
         shell: bash
@@ -42,7 +42,13 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
-      
+
+      - name: Install optional dependencies
+        # Only install optional dependencies on one runner
+        if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.12'
+        run: |
+          pip install .[excel]
+
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/docs/source/changelog.md
+++ b/docs/source/changelog.md
@@ -8,6 +8,8 @@ Release notes for the `space_packet_parser` library
 ### v5.1.0 (unreleased)
 - BUGFIX: Fix kbps calculation in packet generator for showing progress.
 - Add support for string and float encoded enumerated lookup parameters.
+- Add an Excel spreadsheet definition to XTCE conversion utility to enable a quicker way
+  to get started with XTCE definitions. The current format supports GSEOS-style packet definitions.
 
 ### v5.0.1 (released)
 - BUGFIX: Allow raw_value representation for enums with falsy raw values. Previously these defaulted to the enum label.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,6 +58,9 @@ optional = true
 matplotlib = ">=3.4"
 memory-profiler = "^0.61.0"
 
+[tool.poetry.scripts]
+spp-convert = "space_packet_parser.converters:main"
+
 [build-system]
 requires = ["poetry-core>=1.0.0"]
 build-backend = "poetry.core.masonry.api"

--- a/space_packet_parser/converters.py
+++ b/space_packet_parser/converters.py
@@ -1,0 +1,502 @@
+"""
+Convert an Excel file of packet definitions into the XTCE format.
+
+This script reads in an Excel file containing packet definitions and converts
+them into an XTCE file.
+
+.. code::
+  spp-convert /path/to/excel_file.xlsx --output /path/to/output.xml
+"""
+
+import argparse
+import xml.etree.ElementTree as Et
+from importlib.util import find_spec
+from pathlib import Path
+
+try:
+    import pandas as pd
+    _HAS_PANDAS = True
+except ImportError:
+    _HAS_PANDAS = False
+
+if not find_spec("openpyxl"):
+    # Also test for openpyxl which is panda's optional Excel engine
+    _HAS_PANDAS = False
+
+_CCSDS_PARAMETERS = [
+    {
+        "name": "VERSION",
+        "lengthInBits": 3,
+        "description": "CCSDS Packet Version Number (always 0)",
+    },
+    {
+        "name": "TYPE",
+        "lengthInBits": 1,
+        "description": "CCSDS Packet Type Indicator (0=telemetry)",
+    },
+    {
+        "name": "SEC_HDR_FLG",
+        "lengthInBits": 1,
+        "description": "CCSDS Packet Secondary Header Flag (always 1)",
+    },
+    {
+        "name": "PKT_APID",
+        "lengthInBits": 11,
+        "description": "CCSDS Packet Application Process ID",
+    },
+    {
+        "name": "SEQ_FLGS",
+        "lengthInBits": 2,
+        "description": "CCSDS Packet Grouping Flags (3=not part of group)",
+    },
+    {
+        "name": "SRC_SEQ_CTR",
+        "lengthInBits": 14,
+        "description": "CCSDS Packet Sequence Count "
+        "(increments with each new packet)",
+    },
+    {
+        "name": "PKT_LEN",
+        "lengthInBits": 16,
+        "description": "CCSDS Packet Length "
+        "(number of bytes after Packet length minus 1)",
+    },
+]
+
+
+class Excel:
+    """
+    Automatically generate XTCE files from an Excel spreadsheet definition file.
+
+    There must be a sheet named "Packets" that contains a mapping from packetName to apId.
+    Each packet definition is contained in its own sheet named "packetName".
+
+    The packet definition sheets must have the following columns:
+      * mnemonic
+      * lengthInBits
+      * dataType
+    with optional extra columns:
+      * convertAs (ANALOG, STATE)
+      * shortDescription
+      * longDescription
+
+    Some names can be duplicated across packet definitions, but have different
+    lengths or data types (i.e. SPARE/FILL). To disambiguate these, the XTCE parameterRef
+    is created by combining the packetName and mnemonic with a period: `packetName.mnemonic`.
+
+    Parameters
+    ----------
+    path_to_excel_file : Path
+        Path to the excel file.
+
+    Usage
+    -----
+    Excel("/path/to/definition.xlsx").to_xtce("/path/to/xtce-definition.xml")
+    """
+
+    def __init__(self, path_to_excel_file: Path, namespace="http://www.omg.org/space/xtce"):
+        if not _HAS_PANDAS:
+            raise ImportError(
+                "The pandas and openpyxl packages are required to convert an Excel sheet to XTCE. "
+                "Please install them using 'pip install pandas openpyxl'."
+            )
+        # Read in all sheets from the excel file
+        self.sheets = pd.read_excel(path_to_excel_file, sheet_name=None)
+        if "Packets" not in self.sheets:
+            raise ValueError(
+                "The excel file must contain a sheet named 'Packets' that contains a mapping "
+                "from packetName to apId."
+            )
+        # Set up the packet mapping from packetName to Apid
+        packet_sheet = self.sheets["Packets"]
+        if "packetName" not in packet_sheet.columns:
+            raise ValueError(
+                "The excel file must contain a column named 'packetName' in the 'Packets' sheet."
+            )
+        if "apId" not in packet_sheet.columns:
+            if "apIdHex" not in packet_sheet.columns:
+                raise ValueError(
+                    "The excel file must contain a column named 'apId' or 'apIdHex' in the 'Packets' sheet."
+                )
+            # Create the apId column from the apIdHex (base=0 works with the 0x prefix)
+            packet_sheet["apId"] = packet_sheet["apIdHex"].apply(int, base=0)
+        self._packet_mapping = packet_sheet.set_index("packetName")["apId"].to_dict()
+
+        self._namespace = namespace
+        # Create the XML containers that will be populated later
+        self._setup_xml_containers()
+        # Add the CCSDS Header information to the containers
+        self._setup_ccsds_header()
+        # Create the sequence containers (also adding parameters within)
+        self._create_container_sets()
+
+    def _setup_xml_containers(self) -> None:
+        """Create an XML representation of telemetry data."""
+        # Create the root element and add namespaces
+        self._root = root = Et.Element("xtce:SpaceSystem")
+        root.attrib["xmlns:xtce"] = self._namespace
+        if "Subsystem" in self.sheets:
+            # Subsystem sheet name is used as the base name for this XTCE definition
+            subsystem = self.sheets["Subsystem"]
+            root.attrib["name"] = str(
+                subsystem.loc[subsystem["infoField"] == "subsystem", "infoValue"].values[0]
+            )
+            # Create the Header element with attributes 'date', 'version', and 'author'
+            # Versioning is used to keep track of changes to the XML file.
+            header = Et.SubElement(root, "xtce:Header")
+            header.attrib["date"] = str(
+                subsystem.loc[
+                    subsystem["infoField"] == "sheetReleaseDate", "infoValue"
+                ].values[0]
+            )
+            header.attrib["version"] = str(
+                subsystem.loc[
+                    subsystem["infoField"] == "sheetReleaseRev", "infoValue"
+                ].values[0]
+            )
+            header.attrib["author"] = "Space Packet Parser"
+
+        # Create the TelemetryMetaData element
+        self._telemetry_metadata = Et.SubElement(root, "xtce:TelemetryMetaData")
+
+        # Create the ParameterTypeSet element
+        self._parameter_type_set = Et.SubElement(
+            self._telemetry_metadata, "xtce:ParameterTypeSet"
+        )
+
+        # Create the ParameterSet element
+        self._parameter_set = Et.SubElement(
+            self._telemetry_metadata, "xtce:ParameterSet"
+        )
+
+        # Create ContainerSet element
+        self._container_sets = Et.SubElement(
+            self._telemetry_metadata, "xtce:ContainerSet"
+        )
+
+    def _setup_ccsds_header(self) -> None:
+        """Fill in the default CCSDS header information."""
+        # Create CCSDSPacket SequenceContainer
+        ccsds_container = Et.SubElement(self._container_sets, "xtce:SequenceContainer")
+        ccsds_container.attrib["name"] = "CCSDSPacket"
+        ccsds_container.attrib["abstract"] = "true"
+        ccsds_entry_list = Et.SubElement(ccsds_container, "xtce:EntryList")
+
+        # Populate EntryList for CCSDSPacket SequenceContainer
+        for parameter_data in _CCSDS_PARAMETERS:
+            parameter_ref_entry = Et.SubElement(
+                ccsds_entry_list, "xtce:ParameterRefEntry"
+            )
+            name = str(parameter_data["name"])
+
+            parameter_ref_entry.attrib["parameterRef"] = name
+
+            # Add the parameter to the ParameterSet
+            parameter = Et.SubElement(self._parameter_set, "xtce:Parameter")
+            parameter.attrib["name"] = name
+            parameter.attrib["parameterTypeRef"] = name
+
+            description = Et.SubElement(parameter, "xtce:LongDescription")
+            description.text = str(parameter_data["description"])
+
+            # Add the typeref to the parameter type set
+            parameter_type = Et.SubElement(
+                self._parameter_type_set, "xtce:IntegerParameterType"
+            )
+            parameter_type.attrib["name"] = name
+            parameter_type.attrib["signed"] = "false"
+
+            encoding = Et.SubElement(parameter_type, "xtce:IntegerDataEncoding")
+            encoding.attrib["sizeInBits"] = str(parameter_data["lengthInBits"])
+            encoding.attrib["encoding"] = "unsigned"
+
+    def _create_container_sets(self) -> None:
+        """Create a container set for each packet in the Excel file."""
+        # Iterate over all packets and create Packet SequenceContainers
+        for packet_name, apid in self._packet_mapping.items():
+            # Populate EntryList for packet SequenceContainers
+            # The sheets are sometimes prefixed with P_, so we need to try both options
+            packet_df = self.sheets.get(packet_name, self.sheets.get(f"P_{packet_name}"))
+            if packet_df is None:
+                print(
+                    f"Packet definition for {packet_name} "
+                    "not found in the excel file as a separate tab, skipping the XTCE creation."
+                )
+                continue
+            if any(x not in packet_df.columns for x in ["mnemonic", "lengthInBits", "dataType"]):
+                print(
+                    f"Packet definition for {packet_name}  does not contain the required columns "
+                    "(mnemonic, lengthInBits, dataType), skipping the XTCE creation."
+                )
+                continue
+            # Create Packet SequenceContainer that use the CCSDSPacket SequenceContainer
+            # as the base container
+            science_container = Et.SubElement(
+                self._container_sets, "xtce:SequenceContainer"
+            )
+            science_container.attrib["name"] = packet_name
+
+            # Every container should inherit from the base container, CCSDSPacket
+            base_container = Et.SubElement(science_container, "xtce:BaseContainer")
+            base_container.attrib["containerRef"] = "CCSDSPacket"
+
+            # Add RestrictionCriteria element to use the given APID for comparison
+            restriction_criteria = Et.SubElement(
+                base_container, "xtce:RestrictionCriteria"
+            )
+            comparison = Et.SubElement(restriction_criteria, "xtce:Comparison")
+            comparison.attrib["parameterRef"] = "PKT_APID"
+            comparison.attrib["value"] = str(apid)
+            comparison.attrib["useCalibratedValue"] = "false"
+
+            packet_entry_list = Et.SubElement(science_container, "xtce:EntryList")
+            # Needed for dynamic binary packet length
+            total_packet_bits = int(packet_df["lengthInBits"].sum())
+            for i, row in packet_df.iterrows():
+                if i < 7:
+                    # Skip first 7 rows as they are the CCSDS header elements
+                    # TODO: Do we want to leave these in for explicit (non-abstract) containers?
+                    continue
+                if pd.isna(row.get("packetName")):
+                    # This is a poorly formatted row, skip it
+                    continue
+                # separate the packet name and mnemonic with a period
+                # a hyphen is sometimes in the packet name or mnemonic already
+                name = f"{row['packetName']}.{row['mnemonic']}"
+                parameter_ref_entry = Et.SubElement(
+                    packet_entry_list, "xtce:ParameterRefEntry"
+                )
+                parameter_ref_entry.attrib["parameterRef"] = name
+                # Add this parameter to the ParameterSet too
+                self._add_parameter(row, total_packet_bits)
+
+    def _add_parameter(self, row: 'pd.Series', total_packet_bits: int) -> None:  # pylint: disable=too-many-statements
+        """
+        Row from a packet definition to be added to the XTCE file.
+
+        Parameters
+        ----------
+        row : pandas.Row
+            Row to be added to the XTCE file, containing mnemonic, lengthInBits, ...
+        total_packet_bits : int
+            Total number of bits in the packet, as summed from the lengthInBits column.
+        """
+        parameter = Et.SubElement(self._parameter_set, "xtce:Parameter")
+        # Combine the packet name and mnemonic to create a unique parameter name
+        name = f"{row['packetName']}.{row['mnemonic']}"
+        parameter.attrib["name"] = name
+        parameter.attrib["parameterTypeRef"] = name
+
+        # Add descriptions if they exist
+        if pd.notna(row.get("shortDescription")):
+            parameter.attrib["shortDescription"] = row.get("shortDescription")
+        if pd.notna(row.get("longDescription")):
+            description = Et.SubElement(parameter, "xtce:LongDescription")
+            description.text = row.get("longDescription")
+
+        length_in_bits = int(row["lengthInBits"])
+
+        # Add the parameterTypeRef for this row
+        if "UINT" in row["dataType"] or "FILL" in row["dataType"]:
+            parameter_type = Et.SubElement(
+                self._parameter_type_set, "xtce:IntegerParameterType"
+            )
+            parameter_type.attrib["name"] = name
+            parameter_type.attrib["signed"] = "false"
+
+            encoding = Et.SubElement(parameter_type, "xtce:IntegerDataEncoding")
+            encoding.attrib["sizeInBits"] = str(length_in_bits)
+            encoding.attrib["encoding"] = "unsigned"
+
+        elif any(x in row["dataType"] for x in ["SINT", "INT"]):
+            parameter_type = Et.SubElement(
+                self._parameter_type_set, "xtce:IntegerParameterType"
+            )
+            parameter_type.attrib["name"] = name
+            parameter_type.attrib["signed"] = "true"
+            encoding = Et.SubElement(parameter_type, "xtce:IntegerDataEncoding")
+            encoding.attrib["sizeInBits"] = str(length_in_bits)
+            encoding.attrib["encoding"] = "signed"
+
+        elif "FLOAT" in row["dataType"]:
+            parameter_type = Et.SubElement(
+                self._parameter_type_set, "xtce:FloatParameterType"
+            )
+            parameter_type.attrib["name"] = name
+            encoding = Et.SubElement(parameter_type, "xtce:FloatDataEncoding")
+            encoding.attrib["sizeInBits"] = str(length_in_bits)
+            encoding.attrib["encoding"] = "IEEE-754"
+
+        elif "BYTE" in row["dataType"]:
+            parameter_type = Et.SubElement(
+                self._parameter_type_set, "xtce:BinaryParameterType"
+            )
+            parameter_type.attrib["name"] = name
+
+            encoding = Et.SubElement(parameter_type, "xtce:BinaryDataEncoding")
+            encoding.attrib["bitOrder"] = "mostSignificantBitFirst"
+
+            size_in_bits = Et.SubElement(encoding, "xtce:SizeInBits")
+
+            # If it is a byte field consider it a dynamic value.
+            dynamic_value = Et.SubElement(size_in_bits, "xtce:DynamicValue")
+            param_ref = Et.SubElement(dynamic_value, "xtce:ParameterInstanceRef")
+            param_ref.attrib["parameterRef"] = "PKT_LEN"
+            linear_adjustment = Et.SubElement(dynamic_value, "xtce:LinearAdjustment")
+            linear_adjustment.attrib["slope"] = str(8)
+            # The length of all other variables (other than this specific one)
+            other_variable_bits = total_packet_bits - length_in_bits
+            # PKT_LEN == number of bytes in the packet data field - 1
+            # So we need to subtract the header bytes plus 1 to get the offset
+            # The amount to subtract to get the intercept is then:
+            # number of other bits in the packet - (6 + 1) * 8
+            linear_adjustment.attrib["intercept"] = str(-int(other_variable_bits - 56))
+
+            # TODO: Do we want to allow fixed length values?
+            # fixed_value = Et.SubElement(size_in_bits, "xtce:FixedValue")
+            # fixed_value.text = str(row["lengthInBits"])
+        else:
+            raise ValueError(f"Unknown data type for {name}: {row['dataType']}")
+
+        if "convertAs" in row:
+            if row["convertAs"] == "ANALOG":
+                # Go look up the conversion in the AnalogConversions tab
+                # and add it to the encoding
+                self._add_analog_conversion(row, encoding)
+            elif row["convertAs"] == "STATE":
+                # Go look up the states in the States tab
+                # and add them to the parameter type
+                self._add_state_conversion(row, parameter_type)
+
+    def _add_analog_conversion(self, row: 'pd.Series', encoding: Et.Element) -> None:
+        """
+        Add an analog conversion to the encoding element.
+
+        Parameters
+        ----------
+        row : pandas.Row
+            Row to be added to the XTCE file, containing mnemonic, packetName.
+        encoding : Element
+            The encoding element to add the conversion to.
+        """
+        # Look up the conversion in the AnalogConversions tab
+        analog_conversion = self.sheets["AnalogConversions"]
+        # conversion is a row from the AnalogConversions sheet
+        conversion = analog_conversion.loc[
+            (analog_conversion["mnemonic"] == row["mnemonic"])
+            & (analog_conversion["packetName"] == row["packetName"])
+        ].iloc[0]
+
+        # Create the Conversion element
+        default_calibrator = Et.SubElement(encoding, "xtce:DefaultCalibrator")
+        polynomial_calibrator = Et.SubElement(
+            default_calibrator, "xtce:PolynomialCalibrator"
+        )
+        # FIXME: Use lowValue / highValue from the conversion sheet
+        # FIXME: Handle segmented polynomials (only using first segment now)
+        for i in range(8):
+            col = f"c{i}"
+            if conversion[col] != 0:
+                term = Et.SubElement(polynomial_calibrator, "xtce:Term")
+                term.attrib["coefficient"] = str(conversion[col])
+                term.attrib["exponent"] = str(i)
+
+    def _add_state_conversion(self, row: 'pd.Series', parameter_type: Et.Element) -> None:
+        """
+        Add a state conversion to the parameter type.
+
+        Changing from an IntegerParameterType to an EnumeratedParameterType. Adding
+        the list of state mappings to the parameter type.
+
+        Parameters
+        ----------
+        row : pandas.Row
+            Row to be added to the XTCE file, containing mnemonic, packetName.
+        parameter_type : Element
+            The parameter type element to add the conversion to.
+        """
+        # It is an EnumeratedParameterType rather than an IntegerParameterType
+        parameter_type.tag = "xtce:EnumeratedParameterType"
+        enumeration_list = Et.SubElement(parameter_type, "xtce:EnumerationList")
+        # Lookup the enumeration states for this parameter from the States sheet
+        state_sheet = self.sheets["States"]
+        state_sheet = state_sheet.loc[
+            (state_sheet["packetName"] == row["packetName"])
+            & (state_sheet["mnemonic"] == row["mnemonic"])
+        ]
+        for _, state_row in state_sheet.iterrows():
+            enumeration = Et.SubElement(enumeration_list, "xtce:Enumeration")
+            enumeration.attrib["value"] = str(state_row["value"])
+            enumeration.attrib["label"] = str(state_row["state"])
+
+    def to_xtce(self, output_xtce_path: Path) -> None:
+        """
+        Create and output an XTCE file from the Element Tree representation.
+
+        Parameters
+        ----------
+        output_xml_path : Path
+            Path to the output XML file.
+        """
+        # Create the XML tree and save the document
+        tree = Et.ElementTree(self._root)
+        Et.indent(tree, space="\t")
+
+        # Use the provided output_xtce_path
+        tree.write(output_xtce_path, encoding="utf-8", xml_declaration=True)
+
+
+# Function to parse command line arguments
+def _parse_args() -> argparse.Namespace:
+    """
+    Parse the command line arguments.
+
+    The expected input format is a required argument of "/path/to/excel_file.xlsx"
+    with an optional argument containing the output path for the XTCE file
+    "/path/to/output.xml".
+
+    Returns
+    -------
+    args : argparse.Namespace
+        An object containing the parsed arguments and their values.
+    """
+    description = (
+        "This command line program generates an instrument specific XTCE file. "
+        "Example usage: spp-convert path/to/excel_packet_file.xlsx --output path/to/output_packet_definition.xml"
+    )
+    output_help = (
+        "Where to save the output XTCE file. "
+        "If not provided, the input file name will be used with a .xml extension."
+    )
+    file_path_help = "Provide the full path to the input excel file."
+
+    parser = argparse.ArgumentParser(prog="spp-convert", description=description)
+    parser.add_argument("excel_file", type=Path, help=file_path_help)
+    parser.add_argument("--output", type=Path, required=False, help=output_help)
+
+    args = parser.parse_args()
+
+    if not args.excel_file.exists():
+        parser.error(f"File not found: {args.excel_file}")
+
+    if not args.output:
+        args.output = args.excel_file.with_suffix(".xml")
+
+    return args
+
+
+def main() -> None:
+    """
+    Generate xtce file from CLI information given.
+
+    The xtce file will be written in an instrument specific subfolder.
+    """
+    # Parse arguments from the command line
+    args = _parse_args()
+
+    # Initialize the class and process the sheets and then output the XTCE file
+    Excel(args.excel_file).to_xtce(args.output)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_data/expected_excel_xtce.xml
+++ b/tests/test_data/expected_excel_xtce.xml
@@ -1,0 +1,171 @@
+<?xml version='1.0' encoding='utf-8'?>
+<xtce:SpaceSystem xmlns:xtce="http://www.omg.org/space/xtce" name="Test Instrument">
+	<xtce:Header date="2024-07-26 00:00:00" version="v1.2" author="Space Packet Parser" />
+	<xtce:TelemetryMetaData>
+		<xtce:ParameterTypeSet>
+			<xtce:IntegerParameterType name="VERSION" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="3" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="TYPE" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="1" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="SEC_HDR_FLG" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="1" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="PKT_APID" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="11" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="SEQ_FLGS" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="2" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="SRC_SEQ_CTR" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="14" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="PKT_LEN" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="16" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="TEST_PACKET.SHCOARSE" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="32" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="TEST_PACKET.VAR_UINT" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="2" encoding="unsigned">
+					<xtce:DefaultCalibrator>
+						<xtce:PolynomialCalibrator>
+							<xtce:Term coefficient="1.5" exponent="0" />
+							<xtce:Term coefficient="2.5" exponent="1" />
+						</xtce:PolynomialCalibrator>
+					</xtce:DefaultCalibrator>
+				</xtce:IntegerDataEncoding>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="TEST_PACKET.VAR_INT" signed="true">
+				<xtce:IntegerDataEncoding sizeInBits="4" encoding="signed" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="TEST_PACKET.VAR_SINT" signed="true">
+				<xtce:IntegerDataEncoding sizeInBits="5" encoding="signed" />
+			</xtce:IntegerParameterType>
+			<xtce:BinaryParameterType name="TEST_PACKET.VAR_BYTE">
+				<xtce:BinaryDataEncoding bitOrder="mostSignificantBitFirst">
+					<xtce:SizeInBits>
+						<xtce:DynamicValue>
+							<xtce:ParameterInstanceRef parameterRef="PKT_LEN" />
+							<xtce:LinearAdjustment slope="8" intercept="-71" />
+						</xtce:DynamicValue>
+					</xtce:SizeInBits>
+				</xtce:BinaryDataEncoding>
+			</xtce:BinaryParameterType>
+			<xtce:IntegerParameterType name="TEST_PACKET.VAR_FILL" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="3" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:FloatParameterType name="TEST_PACKET.VAR_FLOAT">
+				<xtce:FloatDataEncoding sizeInBits="32" encoding="IEEE-754" />
+			</xtce:FloatParameterType>
+			<xtce:EnumeratedParameterType name="TEST_PACKET.VAR_STATE" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="1" encoding="unsigned" />
+				<xtce:EnumerationList>
+					<xtce:Enumeration value="0" label="OFF" />
+					<xtce:Enumeration value="1" label="ON" />
+				</xtce:EnumerationList>
+			</xtce:EnumeratedParameterType>
+			<xtce:IntegerParameterType name="TEST_PACKET2.SHCOARSE" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="32" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="TEST_PACKET2.VAR1" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="2" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+		</xtce:ParameterTypeSet>
+		<xtce:ParameterSet>
+			<xtce:Parameter name="VERSION" parameterTypeRef="VERSION">
+				<xtce:LongDescription>CCSDS Packet Version Number (always 0)</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="TYPE" parameterTypeRef="TYPE">
+				<xtce:LongDescription>CCSDS Packet Type Indicator (0=telemetry)</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="SEC_HDR_FLG" parameterTypeRef="SEC_HDR_FLG">
+				<xtce:LongDescription>CCSDS Packet Secondary Header Flag (always 1)</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="PKT_APID" parameterTypeRef="PKT_APID">
+				<xtce:LongDescription>CCSDS Packet Application Process ID</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="SEQ_FLGS" parameterTypeRef="SEQ_FLGS">
+				<xtce:LongDescription>CCSDS Packet Grouping Flags (3=not part of group)</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="SRC_SEQ_CTR" parameterTypeRef="SRC_SEQ_CTR">
+				<xtce:LongDescription>CCSDS Packet Sequence Count (increments with each new packet)</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="PKT_LEN" parameterTypeRef="PKT_LEN">
+				<xtce:LongDescription>CCSDS Packet Length (number of bytes after Packet length minus 1)</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="TEST_PACKET.SHCOARSE" parameterTypeRef="TEST_PACKET.SHCOARSE">
+				<xtce:LongDescription>Mission elapsed time</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="TEST_PACKET.VAR_UINT" parameterTypeRef="TEST_PACKET.VAR_UINT">
+				<xtce:LongDescription>Unsgned integer data with conversion</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="TEST_PACKET.VAR_INT" parameterTypeRef="TEST_PACKET.VAR_INT">
+				<xtce:LongDescription>Integer data</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="TEST_PACKET.VAR_SINT" parameterTypeRef="TEST_PACKET.VAR_SINT">
+				<xtce:LongDescription>Signed integer data</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="TEST_PACKET.VAR_BYTE" parameterTypeRef="TEST_PACKET.VAR_BYTE">
+				<xtce:LongDescription>Binary data - variable length</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="TEST_PACKET.VAR_FILL" parameterTypeRef="TEST_PACKET.VAR_FILL">
+				<xtce:LongDescription>Fill data</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="TEST_PACKET.VAR_FLOAT" parameterTypeRef="TEST_PACKET.VAR_FLOAT">
+				<xtce:LongDescription>Float data</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="TEST_PACKET.VAR_STATE" parameterTypeRef="TEST_PACKET.VAR_STATE">
+				<xtce:LongDescription>State data</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="TEST_PACKET2.SHCOARSE" parameterTypeRef="TEST_PACKET2.SHCOARSE">
+				<xtce:LongDescription>Mission elapsed time</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="TEST_PACKET2.VAR1" parameterTypeRef="TEST_PACKET2.VAR1" shortDescription="Variable 1 short description">
+				<xtce:LongDescription>Variable 1 long description</xtce:LongDescription>
+			</xtce:Parameter>
+		</xtce:ParameterSet>
+		<xtce:ContainerSet>
+			<xtce:SequenceContainer name="CCSDSPacket" abstract="true">
+				<xtce:EntryList>
+					<xtce:ParameterRefEntry parameterRef="VERSION" />
+					<xtce:ParameterRefEntry parameterRef="TYPE" />
+					<xtce:ParameterRefEntry parameterRef="SEC_HDR_FLG" />
+					<xtce:ParameterRefEntry parameterRef="PKT_APID" />
+					<xtce:ParameterRefEntry parameterRef="SEQ_FLGS" />
+					<xtce:ParameterRefEntry parameterRef="SRC_SEQ_CTR" />
+					<xtce:ParameterRefEntry parameterRef="PKT_LEN" />
+				</xtce:EntryList>
+			</xtce:SequenceContainer>
+			<xtce:SequenceContainer name="TEST_PACKET">
+				<xtce:BaseContainer containerRef="CCSDSPacket">
+					<xtce:RestrictionCriteria>
+						<xtce:Comparison parameterRef="PKT_APID" value="1" useCalibratedValue="false" />
+					</xtce:RestrictionCriteria>
+				</xtce:BaseContainer>
+				<xtce:EntryList>
+					<xtce:ParameterRefEntry parameterRef="TEST_PACKET.SHCOARSE" />
+					<xtce:ParameterRefEntry parameterRef="TEST_PACKET.VAR_UINT" />
+					<xtce:ParameterRefEntry parameterRef="TEST_PACKET.VAR_INT" />
+					<xtce:ParameterRefEntry parameterRef="TEST_PACKET.VAR_SINT" />
+					<xtce:ParameterRefEntry parameterRef="TEST_PACKET.VAR_BYTE" />
+					<xtce:ParameterRefEntry parameterRef="TEST_PACKET.VAR_FILL" />
+					<xtce:ParameterRefEntry parameterRef="TEST_PACKET.VAR_FLOAT" />
+					<xtce:ParameterRefEntry parameterRef="TEST_PACKET.VAR_STATE" />
+				</xtce:EntryList>
+			</xtce:SequenceContainer>
+			<xtce:SequenceContainer name="TEST_PACKET2">
+				<xtce:BaseContainer containerRef="CCSDSPacket">
+					<xtce:RestrictionCriteria>
+						<xtce:Comparison parameterRef="PKT_APID" value="15" useCalibratedValue="false" />
+					</xtce:RestrictionCriteria>
+				</xtce:BaseContainer>
+				<xtce:EntryList>
+					<xtce:ParameterRefEntry parameterRef="TEST_PACKET2.SHCOARSE" />
+					<xtce:ParameterRefEntry parameterRef="TEST_PACKET2.VAR1" />
+				</xtce:EntryList>
+			</xtce:SequenceContainer>
+		</xtce:ContainerSet>
+	</xtce:TelemetryMetaData>
+</xtce:SpaceSystem>

--- a/tests/unit/test_converters.py
+++ b/tests/unit/test_converters.py
@@ -1,0 +1,270 @@
+"""Testing for xtce generator template."""
+
+import sys
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+from space_packet_parser import converters
+
+pytest.importorskip("pandas", reason="Pandas is required for converting to XTCE format.")
+pytest.importorskip("openpyxl", reason="Openpyxl is required for converting to XTCE format.")
+
+import pandas as pd
+
+
+@pytest.fixture()
+def xtce_excel_file(tmp_path):
+    """Create an excel file for testing.
+
+    Dataframes for each tab of the spreadsheet that then get written to an excel file.
+    """
+    # Create a pandas DataFrame for global attributes
+    subsystem = {
+        "infoField": ["subsystem", "sheetReleaseDate", "sheetReleaseRev"],
+        "infoValue": ["Test Instrument", "2024-07-26 00:00:00", "v1.2"],
+    }
+
+    packets = {"packetName": ["TEST_PACKET", "TEST_PACKET2"], "apIdHex": ["0x1", "0xF"]}
+
+    test_packet1 = {
+        "packetName": ["TEST_PACKET"] * 15,
+        "mnemonic": [
+            "PHVERNO",
+            "PHTYPE",
+            "PHSHF",
+            "PHAPID",
+            "PHGROUPF",
+            "PHSEQCNT",
+            "PHDLEN",
+            "SHCOARSE",
+            "VAR_UINT",
+            "VAR_INT",
+            "VAR_SINT",
+            "VAR_BYTE",
+            "VAR_FILL",
+            "VAR_FLOAT",
+            "VAR_STATE",
+        ],
+        "lengthInBits": [3, 1, 1, 11, 2, 14, 16, 32, 2, 4, 5, 10000, 3, 32, 1],
+        "dataType": [
+            "UINT",
+            "UINT",
+            "UINT",
+            "UINT",
+            "UINT",
+            "UINT",
+            "UINT",
+            "UINT",
+            "UINT",
+            "INT",
+            "SINT",
+            "BYTE",
+            "FILL",
+            "FLOAT",
+            "UINT",
+        ],
+        "convertAs": [
+            "NONE",
+            "NONE",
+            "NONE",
+            "NONE",
+            "NONE",
+            "NONE",
+            "NONE",
+            "NONE",
+            "ANALOG",
+            "NONE",
+            "NONE",
+            "NONE",
+            "NONE",
+            "NONE",
+            "STATE",
+        ],
+        "units": [
+            "DN",
+            "DN",
+            "DN",
+            "DN",
+            "DN",
+            "DN",
+            "DN",
+            "DN",
+            "DN",
+            "DN",
+            "DN",
+            "DN",
+            "DN",
+            "DN",
+            "DN",
+        ],
+        "longDescription": [
+            "CCSDS Packet Version Number",
+            "CCSDS Packet Type Indicator",
+            "CCSDS Packet Secondary Header Flag",
+            "CCSDS Packet Application Process ID",
+            "CCSDS Packet Grouping Flags",
+            "CCSDS Packet Sequence Count",
+            "CCSDS Packet Length",
+            "Mission elapsed time",
+            "Unsgned integer data with conversion",
+            "Integer data",
+            "Signed integer data",
+            "Binary data - variable length",
+            "Fill data",
+            "Float data",
+            "State data",
+        ],
+    }
+
+    test_packet2 = {
+        "packetName": ["TEST_PACKET2"] * 9,
+        "mnemonic": [
+            "PHVERNO",
+            "PHTYPE",
+            "PHSHF",
+            "PHAPID",
+            "PHGROUPF",
+            "PHSEQCNT",
+            "PHDLEN",
+            "SHCOARSE",
+            "VAR1",
+        ],
+        "lengthInBits": [3, 1, 1, 11, 2, 14, 16, 32, 2],
+        "dataType": [
+            "UINT",
+            "UINT",
+            "UINT",
+            "UINT",
+            "UINT",
+            "UINT",
+            "UINT",
+            "UINT",
+            "UINT",
+        ],
+        "convertAs": [
+            "NONE",
+            "NONE",
+            "NONE",
+            "NONE",
+            "NONE",
+            "NONE",
+            "NONE",
+            "NONE",
+            "NONE",
+        ],
+        "units": ["DN", "DN", "DN", "DN", "DN", "DN", "DN", "DN", "DN"],
+        "longDescription": [
+            "CCSDS Packet Version Number",
+            "CCSDS Packet Type Indicator",
+            "CCSDS Packet Secondary Header Flag",
+            "CCSDS Packet Application Process ID",
+            "CCSDS Packet Grouping Flags",
+            "CCSDS Packet Sequence Count",
+            "CCSDS Packet Length",
+            "Mission elapsed time",
+            "Variable 1 long description",
+        ],
+        "shortDescription": [
+            "",
+            "",
+            "",
+            "",
+            "",
+            "",
+            "",
+            "",
+            "Variable 1 short description",
+        ],
+    }
+
+    analog_conversions = {
+        "packetName": ["TEST_PACKET"],
+        "mnemonic": ["VAR_UINT"],
+        "convertAs": ["UNSEGMENTED_POLY"],
+        "segNumber": [1],
+        "lowValue": [0],
+        "highValue": [100],
+        "c0": [1.5],
+        "c1": [2.5],
+        "c2": [0],
+        "c3": [0],
+        "c4": [0],
+        "c5": [0],
+        "c6": [0],
+        "c7": [0],
+    }
+
+    states = {
+        "packetName": ["TEST_PACKET"] * 2,
+        "mnemonic": ["VAR_STATE"] * 2,
+        "value": [0, 1],
+        "state": ["OFF", "ON"],
+    }
+
+    # Write the DataFrame to an excel file
+    excel_path = tmp_path / "excel_to_xtce_test_file.xlsx"
+    excel_file = pd.ExcelWriter(excel_path, engine="openpyxl")
+
+    pd.DataFrame(subsystem).to_excel(excel_file, sheet_name="Subsystem", index=False)
+    pd.DataFrame(packets).to_excel(excel_file, sheet_name="Packets", index=False)
+    pd.DataFrame(test_packet1).to_excel(
+        excel_file, sheet_name="TEST_PACKET", index=False
+    )
+    # Test P_ version of sheet name as well
+    pd.DataFrame(test_packet2).to_excel(
+        excel_file, sheet_name="P_TEST_PACKET2", index=False
+    )
+    pd.DataFrame(analog_conversions).to_excel(
+        excel_file, sheet_name="AnalogConversions", index=False
+    )
+    pd.DataFrame(states).to_excel(excel_file, sheet_name="States", index=False)
+
+    # Write the file to disk
+    excel_file.close()
+
+    return excel_path
+
+
+def test_generated_xtce(xtce_excel_file):
+    """Make sure we are producing the expected contents within the XML file.
+    
+    Uncomment the `generator.to_xtce(expected_file)` line to create the expected output file.
+    """
+    generator = converters.Excel(xtce_excel_file)
+    output_file = xtce_excel_file.parent / "output.xml"
+    generator.to_xtce(output_file)
+
+    expected_file = Path(__file__).parent.parent / "test_data/expected_excel_xtce.xml"
+    # NOTE: Uncomment this line if you want to re-create the expected output file
+    # generator.to_xtce(expected_file)
+    with open(output_file) as f, open(expected_file) as f_expected:
+        assert f.read() == f_expected.read()
+
+
+@mock.patch("space_packet_parser.converters.Excel")
+def test_main_general(mock_input, xtce_excel_file):
+    """Valid input should only be called once and not raise any errors."""
+    test_args = [
+        "spp-convert",
+        "--output",
+        "test.xml",
+        f"{xtce_excel_file}",
+    ]
+    with mock.patch.object(sys, "argv", test_args):
+        converters.main()
+        mock_input.assert_called_once()
+
+
+# Testing without required arguments
+def test_main_inval_arg():
+    """Raises when no input Excel file is present."""
+    test_args = [
+        "spp-convert",
+        "--output",
+        "test.xml",
+    ]
+    with mock.patch.object(sys, "argv", test_args):
+        with pytest.raises(SystemExit):
+            converters.main()


### PR DESCRIPTION
This adds a utility function that converts spreadsheet definition files (GSEOS format?) into XTCE definitions that space_packet_parser can read and use.

closes https://github.com/medley56/space_packet_parser/discussions/74

## Checklist
- [x] Changes are fully implemented without dangling issues or TODO items
- [x] Deprecated/superseded code is removed or marked with deprecation warning
- [x] Current dependencies have been properly specified and old dependencies removed
- [x] New code/functionality has accompanying tests and any old tests have been updated to match any new assumptions
- [x] The changelog.md has been updated
