### PR TITLE
Add continuation packet support

### DIFF
--- a/docs/source/changelog.md
+++ b/docs/source/changelog.md
@@ -16,6 +16,13 @@ Release notes for the `space_packet_parser` library
   streams as needed.
 - Add a ``ccsds_packet_generator()`` function that iterates through raw
   bytes and yields individual CCSDS packets.
+- Add continuation packet support to the XTCE parsing and packet generation.
+  This adds logic to concatenate packet data fields together across successive
+  packets (if there was too much data to fit in a single CCSDS packet or it
+  was logically better to split by other teams).
+  - Add warnings if packets are out of sequence within a given apid.
+  - Add ability to remove secondary header bytes from subsequent packets.
+    ``definition.packet_generator(data, combine_segmented_packets=True, secondary_header_bytes=4)``
 
 ### v5.0.1 (released)
 - BUGFIX: Allow raw_value representation for enums with falsy raw values. Previously these defaulted to the enum label.


### PR DESCRIPTION
This builds on the packet refactor work (the final commit of this PR is relevant to continuation packets) and adds continuation packet support to the XTCE parsing and packet generation. This adds logic to concatenate packet data fields together across successive packets (if there was too much data to fit in a single CCSDS packet or it was logically better to split by other teams).
- Add warnings if packets are out of sequence within a given apid.
- Add ability to remove secondary header bytes from subsequent packets.
  ``definition.packet_generator(data, combine_segmented_packets=True, secondary_header_bytes=4)``

Notes:
- This is only in the XTCE packet parsing definition generator for now, so thoughts on doing this up a level are welcome. I chose not to to keep it as "raw" as possible at that stage, but could see an argument either way.
- I've chosen to keep old behavior with `combine_segmented_packets=False`, so this is opt-in behavior. I'm not sure if that is what we should do or if we should start combining them right away and have it be opt-out instead?

closes #114

## Checklist
- [x] Changes are fully implemented without dangling issues or TODO items
- [x] Deprecated/superseded code is removed or marked with deprecation warning
- [x] Current dependencies have been properly specified and old dependencies removed
- [x] New code/functionality has accompanying tests and any old tests have been updated to match any new assumptions
- [x] The changelog.md has been updated
