### PR TITLE
MNT: Change logger warning to UserWarning and ignore some inconsequential test warnings

### DIFF
--- a/docs/source/changelog.md
+++ b/docs/source/changelog.md
@@ -11,6 +11,7 @@ Release notes for the `space_packet_parser` library
 
 ### v5.0.1 (released)
 - BUGFIX: Allow raw_value representation for enums with falsy raw values. Previously these defaulted to the enum label.
+- If a packet definition parses too few bits, a UserWarning is now emitted instead of a logger warning.
 
 ### v5.0.0 (released)
 - *BREAKING*: Main API changed. No need to create separate definition and parser objects any more. Create only a 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,3 +61,8 @@ memory-profiler = "^0.61.0"
 [build-system]
 requires = ["poetry-core>=1.0.0"]
 build-backend = "poetry.core.masonry.api"
+
+[tool.pytest.ini_options]
+filterwarnings = [
+    "ignore:You are encoding a BooleanParameterType:UserWarning",
+]

--- a/space_packet_parser/calibrators.py
+++ b/space_packet_parser/calibrators.py
@@ -332,12 +332,10 @@ class ContextCalibrator(comparisons.AttrComparable):
         """
         match_criteria = cls.get_context_match_criteria(element, ns)
 
-        if element.find('xtce:Calibrator/xtce:SplineCalibrator', ns) is not None:
-            calibrator = SplineCalibrator.from_calibrator_xml_element(
-                element.find('xtce:Calibrator/xtce:SplineCalibrator', ns), ns)
-        elif element.find('xtce:Calibrator/xtce:PolynomialCalibrator', ns):
-            calibrator = PolynomialCalibrator.from_calibrator_xml_element(
-                element.find('xtce:Calibrator/xtce:PolynomialCalibrator', ns), ns)
+        if (cal_element := element.find('xtce:Calibrator/xtce:SplineCalibrator', ns)) is not None:
+            calibrator = SplineCalibrator.from_calibrator_xml_element(cal_element, ns)
+        elif (cal_element := element.find('xtce:Calibrator/xtce:PolynomialCalibrator', ns)) is not None:
+            calibrator = PolynomialCalibrator.from_calibrator_xml_element(cal_element, ns)
         else:
             raise NotImplementedError(
                 "Unsupported default_calibrator type. space_packet_parser only supports Polynomial and Spline"

--- a/space_packet_parser/definitions.py
+++ b/space_packet_parser/definitions.py
@@ -8,6 +8,7 @@ from pathlib import Path
 import socket
 import time
 from typing import Tuple, Optional, List, TextIO, Dict, Union, BinaryIO, Iterator
+import warnings
 # Installed
 import lxml.etree as ElementTree
 # Local
@@ -636,11 +637,11 @@ class XtcePacketDefinition:
 
             actual_length_parsed = packet.raw_data.pos // 8
             if actual_length_parsed != n_bytes_packet:
-                logger.warning(f"Parsed packet length "
-                               f"({actual_length_parsed}B) did not match "
-                               f"length specified in header ({n_bytes_packet}B). "
-                               f"Updating the position to the correct position "
-                               "indicated by CCSDS header.")
+                warnings.warn(f"Parsed packet length "
+                              f"({actual_length_parsed}B) did not match "
+                              f"length specified in header ({n_bytes_packet}B). "
+                              f"Updating the position to the correct position "
+                              f"indicated by CCSDS header.")
                 if not parse_bad_pkts:
                     logger.warning(f"Skipping (not yielding) bad packet with apid {header['PKT_APID']}.")
                     continue

--- a/space_packet_parser/encodings.py
+++ b/space_packet_parser/encodings.py
@@ -75,9 +75,7 @@ class DataEncoding(comparisons.AttrComparable, metaclass=ABCMeta):
         : Union[List[ContextCalibrator], None]
             List of ContextCalibrator objects or None if there are no context calibrators
         """
-        if data_encoding_element.find('xtce:ContextCalibratorList', ns):
-            context_calibrators_elements = data_encoding_element.findall(
-                'xtce:ContextCalibratorList/xtce:ContextCalibrator', ns)
+        if (context_calibrators_elements := data_encoding_element.find('xtce:ContextCalibratorList', ns)) is not None:
             return [calibrators.ContextCalibrator.from_context_calibrator_xml_element(el, ns)
                     for el in context_calibrators_elements]
         return None

--- a/space_packet_parser/parameters.py
+++ b/space_packet_parser/parameters.py
@@ -429,10 +429,8 @@ class TimeParameterType(ParameterType, metaclass=ABCMeta):
         : Union[str, None]
             Unit string or None if no units are defined
         """
-        encoding_element = parameter_type_element.find('xtce:Encoding', ns)
-        if encoding_element and "units" in encoding_element.attrib:
-            units = encoding_element.attrib["units"]
-            return units
+        if (encoding_element := parameter_type_element.find('xtce:Encoding', ns)) is not None:
+            return encoding_element.attrib.get('units')
         # Units are optional so return None if they aren't specified
         return None
 

--- a/tests/integration/test_xtce_based_parsing/test_ctim_parsing.py
+++ b/tests/integration/test_xtce_based_parsing/test_ctim_parsing.py
@@ -1,8 +1,10 @@
 """Test parsing of CTIM instrument data"""
+import pytest
 # Local
 from space_packet_parser import definitions
 
 
+@pytest.mark.filterwarnings("ignore:Parsed packet length")
 def test_ctim_parsing(ctim_test_data_dir):
     """Test parsing CTIM data"""
     print("Loading and parsing packet definition")

--- a/tests/unit/test_xtcedef.py
+++ b/tests/unit/test_xtcedef.py
@@ -220,6 +220,7 @@ def test_attr_comparable():
          {}, 3, ComparisonError("Fails to parse a float string 3.0 into an int")),
     ]
 )
+@pytest.mark.filterwarnings("ignore:Performing a comparison against a current value")
 def test_comparison(xml_string, test_parsed_data, current_parsed_value, expected_comparison_result):
     """Test Comparison object"""
     element = ElementTree.fromstring(xml_string)


### PR DESCRIPTION
- Emit UserWarning for more visible issues with XTCE definitions.
- Filter out warnings emitted by the tests that aren't of interest to the tests themselves. Fix some element tree comparisons that had future warnings indicating an explicit check against "is None" was needed. (There are now zero warnings when running pytest)
- Use the walrus operator for assignment to avoid duplicate lookups with element tree find calls. (There are probably more places that this could be helpful, but I just fixed the places with warnings)

closes #116 

## Checklist
- [x] Changes are fully implemented without dangling issues or TODO items
- [x] Deprecated/superseded code is removed or marked with deprecation warning
- [x] Current dependencies have been properly specified and old dependencies removed
- [x] New code/functionality has accompanying tests and any old tests have been updated to match any new assumptions
- [x] The changelog.md has been updated
