### PR TITLE
Modify IMAP code to create generic xarray dataset from packet data file

### DIFF
--- a/.github/workflows/pr_tests.yml
+++ b/.github/workflows/pr_tests.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install . pytest pytest-randomly
+          pip install ".[xarray]" pytest pytest-randomly
       
       - name: Testing
         run: |

--- a/docs/source/changelog.md
+++ b/docs/source/changelog.md
@@ -25,6 +25,8 @@ Release notes for the `space_packet_parser` library
     ``definition.packet_generator(data, combine_segmented_packets=True, secondary_header_bytes=4)``
 - Add a command line interface (spp) to enable quick and easy access to
   some common tasks and utilities.
+- Add function to directly create an `xarray.DataSet` from a packet file and XTCE definition.
+  e.g. `space_packet_parser.xarr.create_dataset([packets1, packets2, ...], definition)`
 
 ### v5.0.1 (released)
 - BUGFIX: Allow raw_value representation for enums with falsy raw values. Previously these defaulted to the enum label.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,9 @@ python = ">=3.9"
 lxml = ">=4.8.0"
 click = "^8.0"
 rich = "^13.0"
+# Extras dependencies
+xarray = { version = ">2024.0.0", optional = true }
+numpy = { version = "^2.0.0", optional = true }
 
 [tool.poetry.group.dev.dependencies]
 pycodestyle = "*"
@@ -59,6 +62,9 @@ optional = true
 [tool.poetry.group.examples.dependencies]
 matplotlib = ">=3.4"
 memory-profiler = "^0.61.0"
+
+[tool.poetry.extras]
+xarray = ["xarray", "numpy"]
 
 [tool.poetry.scripts]
 spp = "space_packet_parser.cli:spp"

--- a/space_packet_parser/definitions.py
+++ b/space_packet_parser/definitions.py
@@ -482,7 +482,8 @@ class XtcePacketDefinition:
 
             if packet.raw_data.pos != len(packet.raw_data) * 8:
                 warnings.warn(f"Number of bits parsed ({packet.raw_data.pos}b) did not match "
-                              f"the length of data available ({len(packet.raw_data) * 8}b).")
+                              f"the length of data available ({len(packet.raw_data) * 8}b) for packet with APID "
+                              f"{packet.raw_data.apid}.")
 
                 if not parse_bad_pkts:
                     logger.warning(f"Skipping (not yielding) bad packet with apid {raw_packet_data.apid}.")

--- a/space_packet_parser/packets.py
+++ b/space_packet_parser/packets.py
@@ -217,8 +217,8 @@ def create_ccsds_packet(data=b"\x00",
                         secondary_header_flag=0,
                         apid=2047,  # 2047 is defined as a fill packet in the CCSDS spec
                         sequence_flags=SequenceFlags.UNSEGMENTED,
-                        sequence_count=0):
-    """Create a binary CCSDS packet.
+                        sequence_count=0) -> RawPacketData:
+    """Create a binary CCSDS packet from input values.
 
     Pack the header fields into the proper bit locations and append the data bytes.
 
@@ -238,6 +238,11 @@ def create_ccsds_packet(data=b"\x00",
         CCSDS Packet Sequence Flags (2 bits)
     sequence_count : int
         CCSDS Packet Sequence Count (14 bits)
+
+    Returns
+    -------
+    : RawPacketData
+        Resulting binary packet
     """
     if version_number < 0 or version_number > 7:  # 3 bits
         raise ValueError("version_number must be between 0 and 7")

--- a/space_packet_parser/xarr.py
+++ b/space_packet_parser/xarr.py
@@ -1,0 +1,214 @@
+"""Extras package that supports generating an `xarray.DataSet` directly"""
+# Extras import first since it might fail
+try:
+    import xarray as xr
+    import numpy as np
+except ImportError as ie:
+    raise ImportError(
+        "Failed to import dependencies for xarray extra. Did you install the [xarray] extras package?"
+    ) from ie
+# Standard
+import collections
+from typing import Optional, Union, Iterable
+from pathlib import Path
+# Local
+from space_packet_parser import definitions, parameters, encodings
+
+
+def _min_dtype_for_encoding(data_encoding: encodings.DataEncoding):
+    """Find the minimum data type capaable of representing an XTCE data encoding.
+
+    This only works for raw values and does not apply to calibrated or otherwise derived values.
+
+    Parameters
+    ----------
+    data_encoding : encodings.DataEncoding
+        The raw data encoding.
+
+    Returns
+    -------
+    : str
+        The numpy dtype string for the minimal representation of the data encoding.
+    """
+    if isinstance(data_encoding, encodings.IntegerDataEncoding):
+        nbits = data_encoding.size_in_bits
+        datatype = "int"
+        if data_encoding.encoding == "unsigned":
+            datatype = "uint"
+        if nbits <= 8:
+            datatype += "8"
+        elif nbits <= 16:
+            datatype += "16"
+        elif nbits <= 32:
+            datatype += "32"
+        else:
+            datatype += "64"
+    elif isinstance(data_encoding, encodings.FloatDataEncoding):
+        nbits = data_encoding.size_in_bits
+        datatype = "float"
+        if nbits == 32:
+            datatype += "32"
+        else:
+            datatype += "64"
+    elif isinstance(data_encoding, encodings.BinaryDataEncoding):
+        datatype = "bytes"
+    elif isinstance(data_encoding, encodings.StringDataEncoding):
+        datatype = "str"
+    else:
+        raise ValueError(f"Unrecognized data encoding type {data_encoding}.")
+
+    return datatype
+
+
+def _get_minimum_numpy_datatype(  # noqa: PLR0912 - Too many branches pylint: disable=too-many-branches
+        name: str,
+        definition: definitions.XtcePacketDefinition,
+        use_raw_value: bool = False
+) -> Optional[str]:
+    """
+    Get the minimum datatype for a given variable.
+
+    Parameters
+    ----------
+    name : str
+        The variable name.
+    definition : definitions.XtcePacketDefinition
+        The XTCE packet definition. Used to examine data types to infer their niminal numpy representation.
+    use_raw_value : bool
+        Default False. If True, uses the data type of the raw value for each parameter.
+
+    Returns
+    -------
+    datatype : Optional[str]
+        The minimum numpy dtype for the parameter.
+        Returns None to indicate that numpy should use default dtype inference.
+    """
+    parameter_type = definition.named_parameters[name].parameter_type
+    data_encoding = parameter_type.encoding
+
+    if use_raw_value:
+        # If we are using raw values, we can determine the minimal dtype from the parameter data encoding
+        return _min_dtype_for_encoding(data_encoding)
+
+    if isinstance(data_encoding, encodings.NumericDataEncoding):
+        if not (data_encoding.context_calibrators is not None or data_encoding.default_calibrator is not None):
+            # If there are no calibrators attached to the encoding, then we can proceed as if we're using
+            # raw values
+            return _min_dtype_for_encoding(data_encoding)
+        # If there are calibrators present, we really can't know the size of the resulting values.
+        # Let numpy infer the datatype as best it can
+        return None
+
+    if isinstance(data_encoding, encodings.BinaryDataEncoding):
+        return "bytes"
+
+    if isinstance(parameter_type, parameters.EnumeratedParameterType):
+        # Enums are always strings in their derived state
+        return "str"
+
+    if isinstance(data_encoding, encodings.StringDataEncoding):
+        return "str"
+
+    raise ValueError(f"Unsupported data encoding: {data_encoding}")
+
+
+def create_dataset(
+        packet_files: Union[str, Path, Iterable[Union[str, Path]]],
+        xtce_packet_definition: Union[str, Path, definitions.XtcePacketDefinition],
+        use_raw_values: bool = False,
+        **packet_generator_kwargs: any
+):
+    """Create an xarray dataset from an iterable of parsed packet objects
+
+    # TODO: Filter by APID to handle muxed streams?
+
+    Notes
+    -----
+    This function only handles packet definitions with the same variable structure
+    across all packets with the same ApId. For example, this cannot be used for polymorphic
+    packets whose structure changes based on previously parsed values.
+
+    Parameters
+    ----------
+    packet_files : Union[str, Path, Iterable[Union[str, Path]]]
+        Packet files
+    xtce_packet_definition : Union[str, Path, XtcePacketDefinition]
+        Packet definition for parsing the packet data
+    use_raw_values: bool
+        Default False. If True, saves parameter raw values to the resulting DataSet.
+        e.g. enumerated lookups will be saved as their encoded integer values.
+    packet_generator_kwargs : Optional[dict]
+        Keyword arguments passed to `XtcePacketDefinition.packet_generator()`
+
+    Returns
+    -------
+    : xarray.DataSet
+        DataSet object parsed from the iterable of packets.
+    """
+    packet_generator_kwargs = packet_generator_kwargs or {}
+
+    if not isinstance(xtce_packet_definition, definitions.XtcePacketDefinition):
+        xtce_packet_definition = definitions.XtcePacketDefinition(xtce_packet_definition)
+
+    if isinstance(packet_files, (str, Path)):
+        packet_files = [packet_files]
+
+    # Set up containers to store our data
+    # We are getting a packet file that may contain multiple apids
+    # Each apid is expected to contain consistent data fields, so we want to create a
+    # dataset per apid.
+    # {apid1: dataset1, apid2: dataset2, ...}
+    data_dict: dict[int, dict] = {}
+    # Also keep track of the datatype mapping for each field
+    datatype_mapping: dict[int, dict] = {}
+    # Keep track of which variables (keys) are in the dataset
+    variable_mapping: dict[int, set] = {}
+
+    for packet_file in packet_files:
+        with open(packet_file, "rb") as f:
+            packet_generator = list(xtce_packet_definition.packet_generator(f, **packet_generator_kwargs))
+
+        for packet in packet_generator:
+            apid = packet.raw_data.apid
+            if apid not in data_dict:
+                # This is the first packet for this APID
+                data_dict[apid] = collections.defaultdict(list)
+                datatype_mapping[apid] = {}
+                variable_mapping[apid] = packet.keys()
+
+            if variable_mapping[apid] != packet.keys():
+                raise ValueError(
+                    f"Packet fields do not match for APID {apid}. This could be "
+                    f"due to a conditional (polymorphic) packet definition in the XTCE, while this "
+                    f"function currently only supports flat packet definitions."
+                    f"\nExpected: {variable_mapping[apid]},\ngot: {list(packet.keys())}"
+                )
+
+            for key, value in packet.items():
+                if use_raw_values:
+                    # Use the derived value if it exists, otherwise use the raw value
+                    val = value.raw_value
+                else:
+                    val = value
+
+                data_dict[apid][key].append(val)
+                if key not in datatype_mapping[apid]:
+                    # Add this datatype to the mapping
+                    datatype_mapping[apid][key] = _get_minimum_numpy_datatype(
+                        key, xtce_packet_definition, use_raw_value=use_raw_values
+                    )
+
+    # Turn the dict into an xarray dataset
+    dataset_by_apid = {}
+
+    for apid, data in data_dict.items():
+        ds = xr.Dataset(
+            data_vars={
+                key: (["packet"], np.asarray(list_of_values, dtype=datatype_mapping[apid][key]))
+                for key, list_of_values in data.items()
+            }
+        )
+
+        dataset_by_apid[apid] = ds
+
+    return dataset_by_apid

--- a/tests/integration/test_xarr.py
+++ b/tests/integration/test_xarr.py
@@ -1,0 +1,53 @@
+"""Test creating an xarray dataset from CCSDS packets"""
+import pytest
+pytest.importorskip("xarray")
+pytest.importorskip("numpy")
+import numpy as np
+from space_packet_parser.xarr import create_dataset
+
+
+def test_create_xarray_dataset(jpss_test_data_dir):
+    """Test creating an xarray dataset from JPSS geolocation packets"""
+    packet_file = jpss_test_data_dir / "J01_G011_LZ_2021-04-09T00-00-00Z_V01.DAT1"
+    definition_file = jpss_test_data_dir / "jpss1_geolocation_xtce_v1.xml"
+    ds = create_dataset(packet_file, definition_file)
+    assert list(ds.keys()) == [11]
+    assert len(ds[11]) == 27
+    assert len(ds[11]["VERSION"]) == 7200
+    assert ds[11].dtypes == {
+        'VERSION': np.dtype('uint8'), 'TYPE': np.dtype('uint8'), 'SEC_HDR_FLG': np.dtype('uint8'),
+        'PKT_APID': np.dtype('uint16'), 'SEQ_FLGS': np.dtype('uint8'), 'SRC_SEQ_CTR': np.dtype('uint16'),
+        'PKT_LEN': np.dtype('uint16'), 'DOY': np.dtype('uint16'), 'MSEC': np.dtype('uint32'),
+        'USEC': np.dtype('uint16'), 'ADAESCID': np.dtype('uint8'), 'ADAET1DAY': np.dtype('uint16'),
+        'ADAET1MS': np.dtype('uint32'), 'ADAET1US': np.dtype('uint16'), 'ADGPSPOSX': np.dtype('float32'),
+        'ADGPSPOSY': np.dtype('float32'), 'ADGPSPOSZ': np.dtype('float32'), 'ADGPSVELX': np.dtype('float32'),
+        'ADGPSVELY': np.dtype('float32'), 'ADGPSVELZ': np.dtype('float32'), 'ADAET2DAY': np.dtype('uint16'),
+        'ADAET2MS': np.dtype('uint32'), 'ADAET2US': np.dtype('uint16'), 'ADCFAQ1': np.dtype('float32'),
+        'ADCFAQ2': np.dtype('float32'), 'ADCFAQ3': np.dtype('float32'), 'ADCFAQ4': np.dtype('float32')
+    }
+
+
+def test_create_xarray_dataset_multiple_files(jpss_test_data_dir):
+    """Testing parsing multiple files of packets"""
+    packet_file = jpss_test_data_dir / "J01_G011_LZ_2021-04-09T00-00-00Z_V01.DAT1"
+    definition_file = jpss_test_data_dir / "jpss1_geolocation_xtce_v1.xml"
+    ds = create_dataset([packet_file, packet_file], definition_file)
+    assert list(ds.keys()) == [11]
+    assert len(ds[11]) == 27
+    assert len(ds[11]["VERSION"]) == 14400
+
+
+def test_create_xarray_dataset_ctim(ctim_test_data_dir, caplog):
+    """CTIM data contains many APIDs"""
+    packet_file = ctim_test_data_dir / "ccsds_2021_155_14_39_51"
+    definition_file = ctim_test_data_dir / "ctim_xtce_v1.xml"
+    ds = create_dataset(packet_file, definition_file, root_container_name="CCSDSTelemetryPacket", parse_bad_pkts=False)
+    print(ds)
+
+
+def test_create_xarray_dataset_suda(suda_test_data_dir):
+    """SUDA contains a polymorphic packet structure so can't be read into an xarray dataset"""
+    packet_file = suda_test_data_dir / "sciData_2022_130_17_41_53.spl"
+    definition_file = suda_test_data_dir / "suda_combined_science_definition.xml"
+    with pytest.raises(ValueError):  # SUDA has a polymorphic packet structure
+        create_dataset(packet_file, definition_file, skip_header_bytes=4)

--- a/tests/test_data/ctim/ctim_xtce_v1.xml
+++ b/tests/test_data/ctim/ctim_xtce_v1.xml
@@ -9548,6 +9548,7 @@
             <xtce:Parameter name="sw_tec_curr" parameterTypeRef="U16Type"/>
             <xtce:Parameter name="sw_img_state" parameterTypeRef="U16Type"/>
             <xtce:Parameter name="sw_img_currprocType" parameterTypeRef="D16Type"/>
+            <xtce:Parameter name="packet_checksum" parameterTypeRef="U16Type"/>
         </xtce:ParameterSet>
         <xtce:ContainerSet>
             <xtce:SequenceContainer name="CCSDSTelemetryPacket" abstract="true">
@@ -9573,6 +9574,7 @@
                     <xtce:ParameterRefEntry parameterRef="sw_major_version"/>
                     <xtce:ParameterRefEntry parameterRef="sw_minor_version"/>
                     <xtce:ParameterRefEntry parameterRef="sw_patch_version"/>
+                    <xtce:ParameterRefEntry parameterRef="REUSABLE_SPARE_1"/>
                     <xtce:ParameterRefEntry parameterRef="sw_sd_state_card1"/>
                     <xtce:ParameterRefEntry parameterRef="sw_sd_state_card0"/>
                     <xtce:ParameterRefEntry parameterRef="ana_zynq_temp"/>
@@ -9626,6 +9628,7 @@
                     <xtce:ParameterRefEntry parameterRef="sw_tec_curr"/>
                     <xtce:ParameterRefEntry parameterRef="sw_img_state"/>
                     <xtce:ParameterRefEntry parameterRef="sw_img_currprocType"/>
+                    <xtce:ParameterRefEntry parameterRef="packet_checksum"/>
                 </xtce:EntryList>
             </xtce:SequenceContainer>
             <xtce:SequenceContainer name="APID_2_Packet">
@@ -9641,6 +9644,7 @@
                     <xtce:ParameterRefEntry parameterRef="lib_id_err"/>
                     <xtce:ParameterRefEntry parameterRef="lib_entry_num"/>
                     <xtce:ParameterRefEntry parameterRef="lib_entry_store"/>
+                    <xtce:ParameterRefEntry parameterRef="packet_checksum"/>
                 </xtce:EntryList>
             </xtce:SequenceContainer>
             <xtce:SequenceContainer name="APID_3_Packet">
@@ -9659,6 +9663,7 @@
                     <xtce:ParameterRefEntry parameterRef="mem_curr_bytes"/>
                     <xtce:ParameterRefEntry parameterRef="mem_total_bytes"/>
                     <xtce:ParameterRefEntry parameterRef="mem_checksum"/>
+                    <xtce:ParameterRefEntry parameterRef="packet_checksum"/>
                 </xtce:EntryList>
             </xtce:SequenceContainer>
             <xtce:SequenceContainer name="APID_4_Packet">
@@ -9690,6 +9695,7 @@
                     <xtce:ParameterRefEntry parameterRef="hw_uart_sc_par"/>
                     <xtce:ParameterRefEntry parameterRef="hw_uart_sc_rx_count"/>
                     <xtce:ParameterRefEntry parameterRef="hw_uart_sc_tx_count"/>
+                    <xtce:ParameterRefEntry parameterRef="packet_checksum"/>
                 </xtce:EntryList>
             </xtce:SequenceContainer>
             <xtce:SequenceContainer name="APID_6_Packet">
@@ -10223,6 +10229,7 @@
                     <xtce:ParameterRefEntry parameterRef="mem_dump_data_509"/>
                     <xtce:ParameterRefEntry parameterRef="mem_dump_data_510"/>
                     <xtce:ParameterRefEntry parameterRef="mem_dump_data_511"/>
+                    <xtce:ParameterRefEntry parameterRef="packet_checksum"/>
                 </xtce:EntryList>
             </xtce:SequenceContainer>
             <xtce:SequenceContainer name="APID_8_Packet">
@@ -10319,6 +10326,7 @@
                     <xtce:ParameterRefEntry parameterRef="tbl_info_addr_back_outspec_2d"/>
                     <xtce:ParameterRefEntry parameterRef="tbl_info_update_pend_outspec_2d"/>
                     <xtce:ParameterRefEntry parameterRef="SPARE_8"/>
+                    <xtce:ParameterRefEntry parameterRef="packet_checksum"/>
                 </xtce:EntryList>
             </xtce:SequenceContainer>
             <xtce:SequenceContainer name="APID_9_Packet">
@@ -10333,6 +10341,7 @@
                     <xtce:ParameterRefEntry parameterRef="cmd_echo_count"/>
                     <xtce:ParameterRefEntry parameterRef="cmd_echo_status"/>
                     <xtce:ParameterRefEntry parameterRef="SPARE_8"/>
+                    <xtce:ParameterRefEntry parameterRef="packet_checksum"/>
                 </xtce:EntryList>
             </xtce:SequenceContainer>
             <xtce:SequenceContainer name="APID_10_Packet">
@@ -10568,6 +10577,7 @@
                     <xtce:ParameterRefEntry parameterRef="fs_list_file_177"/>
                     <xtce:ParameterRefEntry parameterRef="fs_list_file_187"/>
                     <xtce:ParameterRefEntry parameterRef="fs_list_file_197"/>
+                    <xtce:ParameterRefEntry parameterRef="packet_checksum"/>
                 </xtce:EntryList>
             </xtce:SequenceContainer>
             <xtce:SequenceContainer name="APID_12_Packet">
@@ -10595,6 +10605,7 @@
                     <xtce:ParameterRefEntry parameterRef="cmd_bad_type_count"/>
                     <xtce:ParameterRefEntry parameterRef="cmd_echo_source"/>
                     <xtce:ParameterRefEntry parameterRef="cmd_echo_num"/>
+                    <xtce:ParameterRefEntry parameterRef="packet_checksum"/>
                 </xtce:EntryList>
             </xtce:SequenceContainer>
             <xtce:SequenceContainer name="APID_15_Packet">
@@ -10622,6 +10633,7 @@
                     <xtce:ParameterRefEntry parameterRef="SPARE_8"/>
                     <xtce:ParameterRefEntry parameterRef="log_pub_state"/>
                     <xtce:ParameterRefEntry parameterRef="SPARE_16"/>
+                    <xtce:ParameterRefEntry parameterRef="packet_checksum"/>
                 </xtce:EntryList>
             </xtce:SequenceContainer>
             <xtce:SequenceContainer name="APID_17_Packet">
@@ -10647,6 +10659,7 @@
                     <xtce:ParameterRefEntry parameterRef="tlm_stream_err_count"/>
                     <xtce:ParameterRefEntry parameterRef="SPARE_8"/>
                     <xtce:ParameterRefEntry parameterRef="SPARE_8"/>
+                    <xtce:ParameterRefEntry parameterRef="packet_checksum"/>
                 </xtce:EntryList>
             </xtce:SequenceContainer>
             <xtce:SequenceContainer name="APID_18_Packet">
@@ -10661,6 +10674,7 @@
                     <xtce:ParameterRefEntry parameterRef="time_received"/>
                     <xtce:ParameterRefEntry parameterRef="time_pps_count"/>
                     <xtce:ParameterRefEntry parameterRef="time_miss_count"/>
+                    <xtce:ParameterRefEntry parameterRef="packet_checksum"/>
                 </xtce:EntryList>
             </xtce:SequenceContainer>
             <xtce:SequenceContainer name="APID_20_Packet">
@@ -10681,6 +10695,7 @@
                     <xtce:ParameterRefEntry parameterRef="log_params_1"/>
                     <xtce:ParameterRefEntry parameterRef="log_params_2"/>
                     <xtce:ParameterRefEntry parameterRef="log_params_3"/>
+                    <xtce:ParameterRefEntry parameterRef="packet_checksum"/>
                 </xtce:EntryList>
             </xtce:SequenceContainer>
             <xtce:SequenceContainer name="APID_22_Packet">
@@ -10756,6 +10771,7 @@
                     <xtce:ParameterRefEntry parameterRef="os_task_cpu_usage_sc_tlm"/>
                     <xtce:ParameterRefEntry parameterRef="os_task_cpu_max_sc_tlm"/>
                     <xtce:ParameterRefEntry parameterRef="os_task_exec_cnt_sc_tlm"/>
+                    <xtce:ParameterRefEntry parameterRef="packet_checksum"/>
                 </xtce:EntryList>
             </xtce:SequenceContainer>
             <xtce:SequenceContainer name="APID_23_Packet">
@@ -10776,6 +10792,7 @@
                     <xtce:ParameterRefEntry parameterRef="task_hk_stk_max"/>
                     <xtce:ParameterRefEntry parameterRef="task_hk_id"/>
                     <xtce:ParameterRefEntry parameterRef="task_hk_priority"/>
+                    <xtce:ParameterRefEntry parameterRef="packet_checksum"/>
                 </xtce:EntryList>
             </xtce:SequenceContainer>
             <xtce:SequenceContainer name="APID_24_Packet">
@@ -10801,6 +10818,7 @@
                     <xtce:ParameterRefEntry parameterRef="tec_volt"/>
                     <xtce:ParameterRefEntry parameterRef="tec_avg_curr"/>
                     <xtce:ParameterRefEntry parameterRef="tec_curr"/>
+                    <xtce:ParameterRefEntry parameterRef="packet_checksum"/>
                 </xtce:EntryList>
             </xtce:SequenceContainer>
             <xtce:SequenceContainer name="APID_25_Packet">
@@ -10826,6 +10844,7 @@
                     <xtce:ParameterRefEntry parameterRef="ccd_dac_dd_ccd"/>
                     <xtce:ParameterRefEntry parameterRef="ccd_dac_clkhi_ccd"/>
                     <xtce:ParameterRefEntry parameterRef="ccd_dac_clklo_ccd"/>
+                    <xtce:ParameterRefEntry parameterRef="packet_checksum"/>
                 </xtce:EntryList>
             </xtce:SequenceContainer>
             <xtce:SequenceContainer name="APID_28_Packet">
@@ -10868,6 +10887,7 @@
                     <xtce:ParameterRefEntry parameterRef="fs_vol_free_sector"/>
                     <xtce:ParameterRefEntry parameterRef="fs_vol_used_sector"/>
                     <xtce:ParameterRefEntry parameterRef="fs_vol_tot_sector"/>
+                    <xtce:ParameterRefEntry parameterRef="packet_checksum"/>
                 </xtce:EntryList>
             </xtce:SequenceContainer>
             <xtce:SequenceContainer name="APID_29_Packet">
@@ -10885,6 +10905,7 @@
                     <xtce:ParameterRefEntry parameterRef="os_trace_params_1"/>
                     <xtce:ParameterRefEntry parameterRef="os_trace_params_2"/>
                     <xtce:ParameterRefEntry parameterRef="os_trace_params_3"/>
+                    <xtce:ParameterRefEntry parameterRef="packet_checksum"/>
                 </xtce:EntryList>
             </xtce:SequenceContainer>
             <xtce:SequenceContainer name="APID_30_Packet">
@@ -10915,6 +10936,7 @@
                     <xtce:ParameterRefEntry parameterRef="bct_tlm_time_pps_tai"/>
                     <xtce:ParameterRefEntry parameterRef="SPARE_16"/>
                     <xtce:ParameterRefEntry parameterRef="bct_tlm_time_checksum"/>
+                    <xtce:ParameterRefEntry parameterRef="packet_checksum"/>
                 </xtce:EntryList>
             </xtce:SequenceContainer>
             <xtce:SequenceContainer name="APID_31_Packet">
@@ -10925,6 +10947,7 @@
                 </xtce:BaseContainer>
                 <xtce:EntryList>
                     <xtce:ParameterRefEntry parameterRef="fsw_mode"/>
+                    <xtce:ParameterRefEntry parameterRef="packet_checksum"/>
                 </xtce:EntryList>
             </xtce:SequenceContainer>
             <xtce:SequenceContainer name="APID_32_Packet">
@@ -10952,6 +10975,7 @@
                     <xtce:ParameterRefEntry parameterRef="img_biasStatus_13"/>
                     <xtce:ParameterRefEntry parameterRef="img_biasStatus_14"/>
                     <xtce:ParameterRefEntry parameterRef="img_biasStatus_15"/>
+                    <xtce:ParameterRefEntry parameterRef="packet_checksum"/>
                 </xtce:EntryList>
             </xtce:SequenceContainer>
             <xtce:SequenceContainer name="APID_33_Packet">
@@ -10988,6 +11012,7 @@
                     <xtce:ParameterRefEntry parameterRef="img_pos_error_1_noproc"/>
                     <xtce:ParameterRefEntry parameterRef="img_pos_error_2_noproc"/>
                     <xtce:ParameterRefEntry parameterRef="img_tai_time_noproc"/>
+                    <xtce:ParameterRefEntry parameterRef="packet_checksum"/>
                 </xtce:EntryList>
             </xtce:SequenceContainer>
             <xtce:SequenceContainer name="APID_34_Packet">
@@ -11044,6 +11069,7 @@
                     <xtce:ParameterRefEntry parameterRef="tlm_stat_max_bin2d_proc_roi3"/>
                     <xtce:ParameterRefEntry parameterRef="tlm_stat_mean_bin2d_proc_roi3"/>
                     <xtce:ParameterRefEntry parameterRef="tlm_stat_stddev_bin2d_proc_roi3"/>
+                    <xtce:ParameterRefEntry parameterRef="packet_checksum"/>
                 </xtce:EntryList>
             </xtce:SequenceContainer>
             <xtce:SequenceContainer name="APID_35_Packet">
@@ -11084,6 +11110,7 @@
                     <xtce:ParameterRefEntry parameterRef="tlm_stat_max_bias_proc_over"/>
                     <xtce:ParameterRefEntry parameterRef="tlm_stat_mean_bias_proc_over"/>
                     <xtce:ParameterRefEntry parameterRef="tlm_stat_stddev_bias_proc_over"/>
+                    <xtce:ParameterRefEntry parameterRef="packet_checksum"/>
                 </xtce:EntryList>
             </xtce:SequenceContainer>
             <xtce:SequenceContainer name="APID_36_Packet">
@@ -11136,6 +11163,7 @@
                     <xtce:ParameterRefEntry parameterRef="tlm_stat_max_dark_proc_over"/>
                     <xtce:ParameterRefEntry parameterRef="tlm_stat_mean_dark_proc_over"/>
                     <xtce:ParameterRefEntry parameterRef="tlm_stat_stddev_dark_proc_over"/>
+                    <xtce:ParameterRefEntry parameterRef="packet_checksum"/>
                 </xtce:EntryList>
             </xtce:SequenceContainer>
             <xtce:SequenceContainer name="APID_37_Packet">
@@ -11243,6 +11271,7 @@
                     <xtce:ParameterRefEntry parameterRef="tlm_stat_mean_ospec2d_proc_roi3"/>
                     <xtce:ParameterRefEntry parameterRef="tlm_stat_stddev_ospec2d_proc_roi3"/>
                     <xtce:ParameterRefEntry parameterRef="img_outSpcProcCenter"/>
+                    <xtce:ParameterRefEntry parameterRef="packet_checksum"/>
                 </xtce:EntryList>
             </xtce:SequenceContainer>
             <xtce:SequenceContainer name="APID_38_Packet">
@@ -11309,6 +11338,7 @@
                     <xtce:ParameterRefEntry parameterRef="tlm_stat_stddev_spc1d_proc_over"/>
                     <xtce:ParameterRefEntry parameterRef="img_spc1dProcCenter"/>
                     <xtce:ParameterRefEntry parameterRef="img_spc1dRawCenter"/>
+                    <xtce:ParameterRefEntry parameterRef="packet_checksum"/>
                 </xtce:EntryList>
             </xtce:SequenceContainer>
             <xtce:SequenceContainer name="APID_39_Packet">
@@ -11361,6 +11391,7 @@
                     <xtce:ParameterRefEntry parameterRef="tlm_stat_max_trim2d_proc_roi3"/>
                     <xtce:ParameterRefEntry parameterRef="tlm_stat_mean_trim2d_proc_roi3"/>
                     <xtce:ParameterRefEntry parameterRef="tlm_stat_stddev_trim2d_proc_roi3"/>
+                    <xtce:ParameterRefEntry parameterRef="packet_checksum"/>
                 </xtce:EntryList>
             </xtce:SequenceContainer>
             <xtce:SequenceContainer name="APID_40_Packet">
@@ -11398,6 +11429,7 @@
                     <xtce:ParameterRefEntry parameterRef="img_pos_error_2_cross_d"/>
                     <xtce:ParameterRefEntry parameterRef="img_tai_time_cross_d"/>
                     <xtce:ParameterRefEntry parameterRef="img_cross_d_center"/>
+                    <xtce:ParameterRefEntry parameterRef="packet_checksum"/>
                 </xtce:EntryList>
             </xtce:SequenceContainer>
             <xtce:SequenceContainer name="APID_41_Packet">
@@ -12400,6 +12432,7 @@
                     <xtce:ParameterRefEntry parameterRef="img_frame_data_NOPROC_986"/>
                     <xtce:ParameterRefEntry parameterRef="img_frame_data_NOPROC_987"/>
                     <xtce:ParameterRefEntry parameterRef="img_frame_cksm_NOPROC"/>
+                    <xtce:ParameterRefEntry parameterRef="packet_checksum"/>
                 </xtce:EntryList>
             </xtce:SequenceContainer>
             <xtce:SequenceContainer name="APID_42_Packet">
@@ -13402,6 +13435,7 @@
                     <xtce:ParameterRefEntry parameterRef="img_frame_data_BIN2D_986"/>
                     <xtce:ParameterRefEntry parameterRef="img_frame_data_BIN2D_987"/>
                     <xtce:ParameterRefEntry parameterRef="img_frame_cksm_BIN2D"/>
+                    <xtce:ParameterRefEntry parameterRef="packet_checksum"/>
                 </xtce:EntryList>
             </xtce:SequenceContainer>
             <xtce:SequenceContainer name="APID_43_Packet">
@@ -14404,6 +14438,7 @@
                     <xtce:ParameterRefEntry parameterRef="img_frame_data_BIAS_986"/>
                     <xtce:ParameterRefEntry parameterRef="img_frame_data_BIAS_987"/>
                     <xtce:ParameterRefEntry parameterRef="img_frame_cksm_BIAS"/>
+                    <xtce:ParameterRefEntry parameterRef="packet_checksum"/>
                 </xtce:EntryList>
             </xtce:SequenceContainer>
             <xtce:SequenceContainer name="APID_44_Packet">
@@ -15406,6 +15441,7 @@
                     <xtce:ParameterRefEntry parameterRef="img_frame_data_DARK_986"/>
                     <xtce:ParameterRefEntry parameterRef="img_frame_data_DARK_987"/>
                     <xtce:ParameterRefEntry parameterRef="img_frame_cksm_DARK"/>
+                    <xtce:ParameterRefEntry parameterRef="packet_checksum"/>
                 </xtce:EntryList>
             </xtce:SequenceContainer>
             <xtce:SequenceContainer name="APID_45_Packet">
@@ -16408,6 +16444,7 @@
                     <xtce:ParameterRefEntry parameterRef="img_frame_data_OSPEC2D_986"/>
                     <xtce:ParameterRefEntry parameterRef="img_frame_data_OSPEC2D_987"/>
                     <xtce:ParameterRefEntry parameterRef="img_frame_cksm_OSPEC2D"/>
+                    <xtce:ParameterRefEntry parameterRef="packet_checksum"/>
                 </xtce:EntryList>
             </xtce:SequenceContainer>
             <xtce:SequenceContainer name="APID_46_Packet">
@@ -17410,6 +17447,7 @@
                     <xtce:ParameterRefEntry parameterRef="img_frame_data_SPEC1D_986"/>
                     <xtce:ParameterRefEntry parameterRef="img_frame_data_SPEC1D_987"/>
                     <xtce:ParameterRefEntry parameterRef="img_frame_cksm_SPEC1D"/>
+                    <xtce:ParameterRefEntry parameterRef="packet_checksum"/>
                 </xtce:EntryList>
             </xtce:SequenceContainer>
             <xtce:SequenceContainer name="APID_47_Packet">
@@ -18412,6 +18450,7 @@
                     <xtce:ParameterRefEntry parameterRef="img_frame_data_TRIM2D_986"/>
                     <xtce:ParameterRefEntry parameterRef="img_frame_data_TRIM2D_987"/>
                     <xtce:ParameterRefEntry parameterRef="img_frame_cksm_TRIM2D"/>
+                    <xtce:ParameterRefEntry parameterRef="packet_checksum"/>
                 </xtce:EntryList>
             </xtce:SequenceContainer>
             <xtce:SequenceContainer name="APID_48_Packet">
@@ -19414,6 +19453,7 @@
                     <xtce:ParameterRefEntry parameterRef="img_frame_data_CROSSD_986"/>
                     <xtce:ParameterRefEntry parameterRef="img_frame_data_CROSSD_987"/>
                     <xtce:ParameterRefEntry parameterRef="img_frame_cksm_CROSSD"/>
+                    <xtce:ParameterRefEntry parameterRef="packet_checksum"/>
                 </xtce:EntryList>
             </xtce:SequenceContainer>
         </xtce:ContainerSet>


### PR DESCRIPTION
## Checklist
- [ ] Changes are fully implemented without dangling issues or TODO items
- [x] Deprecated/superseded code is removed or marked with deprecation warning
- [x] Current dependencies have been properly specified and old dependencies removed
- [x] New code/functionality has accompanying tests and any old tests have been updated to match any new assumptions
- [x] The changelog.md has been updated

This is a first stab at a working implementation based on the IMAP code. I removed anything that was particular to IMAP, including the time dimension.