### PR TITLE
CI: Add code coverage reports to external source

### DIFF
--- a/.github/workflows/pr_tests.yml
+++ b/.github/workflows/pr_tests.yml
@@ -36,8 +36,12 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install ".[xarray]" pytest pytest-randomly
+          pip install ".[xarray]" pytest pytest-cov pytest-randomly
       
       - name: Testing
         run: |
-          pytest --color=yes
+          pytest --color=yes --cov
+
+      - uses: codecov/codecov-action@v5
+        with:
+          use_oidc: true

--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,7 @@
 
 # Testing Artifacts #
 #####################
-.coverage
+.coverage*
 coverage_report
 corbertura_report.xml
 tests/test_data/hidden

--- a/space_packet_parser/packets.py
+++ b/space_packet_parser/packets.py
@@ -447,12 +447,8 @@ def ccsds_generator(
 
         # Fill buffer enough to parse a header
         while len(read_buffer) - current_pos < skip_header_bytes + RawPacketData.HEADER_LENGTH_BYTES:
-            try:
-                result = read_bytes_from_source(buffer_read_size_bytes)
-                if not result:  # If there is verifiably no more data to add, break
-                    break
-            except ConnectionResetError:
-                # Forcibly quit
+            result = read_bytes_from_source(buffer_read_size_bytes)
+            if not result:  # If there is verifiably no more data to add, break
                 break
             read_buffer += result
         # Skip the header bytes
@@ -467,12 +463,8 @@ def ccsds_generator(
 
         # Fill the buffer enough to read a full packet, taking into account the user data length
         while len(read_buffer) - current_pos < n_bytes_packet:
-            try:
-                result = read_bytes_from_source(buffer_read_size_bytes)
-                if not result:  # If there is verifiably no more data to add, break
-                    break
-            except ConnectionResetError:
-                # Forcibly quit
+            result = read_bytes_from_source(buffer_read_size_bytes)
+            if not result:  # If there is verifiably no more data to add, break
                 break
             read_buffer += result
 

--- a/space_packet_parser/packets.py
+++ b/space_packet_parser/packets.py
@@ -447,8 +447,12 @@ def ccsds_generator(
 
         # Fill buffer enough to parse a header
         while len(read_buffer) - current_pos < skip_header_bytes + RawPacketData.HEADER_LENGTH_BYTES:
-            result = read_bytes_from_source(buffer_read_size_bytes)
-            if not result:  # If there is verifiably no more data to add, break
+            try:
+                result = read_bytes_from_source(buffer_read_size_bytes)
+                if not result:  # If there is verifiably no more data to add, break
+                    break
+            except ConnectionResetError:
+                # Forcibly quit
                 break
             read_buffer += result
         # Skip the header bytes
@@ -463,8 +467,12 @@ def ccsds_generator(
 
         # Fill the buffer enough to read a full packet, taking into account the user data length
         while len(read_buffer) - current_pos < n_bytes_packet:
-            result = read_bytes_from_source(buffer_read_size_bytes)
-            if not result:  # If there is verifiably no more data to add, break
+            try:
+                result = read_bytes_from_source(buffer_read_size_bytes)
+                if not result:  # If there is verifiably no more data to add, break
+                    break
+            except ConnectionResetError:
+                # Forcibly quit
                 break
             read_buffer += result
 

--- a/tests/integration/test_socket_parsing.py
+++ b/tests/integration/test_socket_parsing.py
@@ -1,7 +1,7 @@
 """Mock socket streaming and listener that decodes on the fly"""
 # Standard
 from contextlib import closing
-from multiprocessing import Process
+from threading import Thread
 import random
 import socket
 import time
@@ -48,13 +48,14 @@ def test_parsing_from_socket(jpss_test_data_dir):
     receiver.settimeout(3)
     with closing(sender), closing(receiver):
         file = jpss_test_data_dir / 'J01_G011_LZ_2021-04-09T00-00-00Z_V01.DAT1'
-        p = Process(target=send_data, args=(sender, file,))
-        p.start()
+        t = Thread(target=send_data, args=(sender, file,))
+        t.start()
 
         packet_generator = xdef.packet_generator(receiver, buffer_read_size_bytes=4096)
         with pytest.raises(socket.timeout):
             packets = []
             for p in packet_generator:
                 packets.append(p)
+        t.join()
 
     assert len(packets) == 7200


### PR DESCRIPTION
I think you need to enable codecov (or some other external service if you prefer) for this to work as I couldn't find a way to enable this. Maybe this is impetus to move to the LASP org so we can both admin things?
https://app.codecov.io/gh

On IMAP we use a token, but I don't think that is required anymore and it would be nice if we can get OIDC to work instead.
https://github.com/IMAP-Science-Operations-Center/imap_processing/blob/693fbdfffd12fa3ec9249f2d5f03fbee39ae5039/.github/workflows/test.yml#L54-L57

I can add a badge once the coverage link/report is enabled.

## Checklist
- [x] Changes are fully implemented without dangling issues or TODO items
- [x] Deprecated/superseded code is removed or marked with deprecation warning
- [x] Current dependencies have been properly specified and old dependencies removed
- [x] New code/functionality has accompanying tests and any old tests have been updated to match any new assumptions
- [n/a] The changelog.md has been updated
